### PR TITLE
Settings Screen Refactor

### DIFF
--- a/apps/mobile/src/components/HeaderScreen/index.tsx
+++ b/apps/mobile/src/components/HeaderScreen/index.tsx
@@ -4,6 +4,8 @@ import {SafeAreaView} from 'react-native-safe-area-context';
 import {useStyles, useTheme} from '../../hooks';
 import {Text} from '../Text';
 import stylesheet from './styles';
+import {Divider} from '../Divider';
+import {Spacing} from '../../styles';
 
 export type HeaderProps = {
   showLogo?: boolean;
@@ -19,7 +21,7 @@ export const HeaderScreen: React.FC<HeaderProps> = ({showLogo = true, left, righ
   return (
     <SafeAreaView edges={['top', 'left', 'right']} style={styles.container}>
       <View style={styles.content}>
-        {left}
+        {left && <View style={styles.leftContainer}>{left}</View>}
 
         {showLogo && (
           <View style={styles.logoContainer}>
@@ -30,7 +32,7 @@ export const HeaderScreen: React.FC<HeaderProps> = ({showLogo = true, left, righ
 
         {title && (
           <View style={styles.title}>
-            <Text weight="bold" color="textStrong" align="center" fontSize={18}>
+            <Text weight="bold" color="textStrong" align="center" fontSize={Spacing.normal}>
               {title}
             </Text>
           </View>
@@ -44,6 +46,8 @@ export const HeaderScreen: React.FC<HeaderProps> = ({showLogo = true, left, righ
           </View>
         )} */}
       </View>
+
+      <Divider style={{marginVertical: 12}} />
     </SafeAreaView>
   );
 };

--- a/apps/mobile/src/components/HeaderScreen/styles.ts
+++ b/apps/mobile/src/components/HeaderScreen/styles.ts
@@ -11,8 +11,9 @@ export default ThemedStyleSheet((theme) => ({
     alignItems: 'center',
     paddingVertical: Spacing.xxsmall,
     paddingHorizontal: Spacing.medium,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: theme.colors.divider,
+  },
+  leftContainer: {
+    position: 'absolute',
   },
 
   logoContainer: {

--- a/apps/mobile/src/components/Input/index.tsx
+++ b/apps/mobile/src/components/Input/index.tsx
@@ -13,6 +13,7 @@ export type InputProps = TextInputProps & {
 
   left?: React.ReactNode;
   right?: React.ReactNode;
+  paddingRight?: boolean;
 
   style?: StyleProp<ViewStyle>;
   containerStyle?: StyleProp<ViewStyle>;
@@ -24,6 +25,7 @@ export const Input: React.FC<InputProps> = (props) => {
     error,
     left,
     right,
+    paddingRight,
     style: styleProp,
     containerStyle: containerStyleProp,
     inputStyle: inputStyleProp,
@@ -31,7 +33,7 @@ export const Input: React.FC<InputProps> = (props) => {
   } = props;
 
   const {theme} = useTheme();
-  const styles = useStyles(stylesheet, !!error, !!left, !!right);
+  const styles = useStyles(stylesheet, !!error, !!left, !!right, !!paddingRight);
 
   return (
     <View style={[styles.container, containerStyleProp]}>

--- a/apps/mobile/src/components/Input/styles.ts
+++ b/apps/mobile/src/components/Input/styles.ts
@@ -1,52 +1,55 @@
 import {Spacing, ThemedStyleSheet, Typography} from '../../styles';
 
-export default ThemedStyleSheet((theme, error: boolean, left: boolean, right: boolean) => ({
-  container: {
-    width: '100%',
-  },
-  content: {
-    borderWidth: 1,
-    borderRadius: 999,
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.small,
-    backgroundColor: theme.colors.inputBackground,
-    borderColor: theme.colors.inputBorder,
-    height: 56,
+export default ThemedStyleSheet(
+  (theme, error: boolean, left: boolean, right: boolean, paddingRight: boolean = true) => ({
+    container: {
+      width: '100%',
+    },
+    content: {
+      borderWidth: 1,
+      borderRadius: 999,
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: Spacing.small,
+      backgroundColor: theme.colors.inputBackground,
+      borderColor: theme.colors.inputBorder,
+      height: 56,
 
-    ...(error && {
-      backgroundColor: theme.colors.errorLight,
-      borderColor: theme.colors.errorDark,
-    }),
+      ...(error && {
+        backgroundColor: theme.colors.errorLight,
+        borderColor: theme.colors.errorDark,
+      }),
 
-    ...(left && {
-      paddingLeft: Spacing.small,
-    }),
+      ...(left && {
+        paddingLeft: Spacing.small,
+      }),
 
-    ...(right && {
-      paddingRight: Spacing.small,
-    }),
-  },
+      ...(right &&
+        paddingRight && {
+          paddingRight: Spacing.small,
+        }),
+    },
 
-  input: {
-    flex: 1,
-    height: '100%',
-    paddingHorizontal: Spacing.large,
-    color: theme.colors.inputText,
-    fontSize: 15,
-    ...Typography.semiBold,
+    input: {
+      flex: 1,
+      height: '100%',
+      paddingHorizontal: Spacing.large,
+      color: theme.colors.inputText,
+      fontSize: 15,
+      ...Typography.semiBold,
 
-    ...(left && {
-      paddingLeft: Spacing.none,
-    }),
+      ...(left && {
+        paddingLeft: Spacing.none,
+      }),
 
-    ...(right && {
-      paddingRight: Spacing.none,
-    }),
-  },
+      ...(right && {
+        paddingRight: Spacing.none,
+      }),
+    },
 
-  errorText: {
-    marginTop: 3,
-    color: theme.colors.errorDark,
-  },
-}));
+    errorText: {
+      marginTop: 3,
+      color: theme.colors.errorDark,
+    },
+  }),
+);

--- a/apps/mobile/src/components/PrivateKeyImport/index.tsx
+++ b/apps/mobile/src/components/PrivateKeyImport/index.tsx
@@ -16,6 +16,7 @@ import {Button} from '../Button';
 import {Input} from '../Input';
 import {Text} from '../Text';
 import styles from './styles';
+import {useWindowDimensions} from '../../hooks';
 
 export const PrivateKeyImport: React.FC = () => {
   const {publicKey, isExtension, privateKey, setAuth} = useAuth();
@@ -23,6 +24,8 @@ export const PrivateKeyImport: React.FC = () => {
   const theme = useTheme();
   const {showToast} = useToast();
   const [password, setPassword] = useState('');
+
+  const {width} = useWindowDimensions();
 
   const handleCopy = async (type: 'privateKey' | 'publicKey') => {
     await Clipboard.setStringAsync(type === 'privateKey' ? privateKey : publicKey);
@@ -58,19 +61,22 @@ export const PrivateKeyImport: React.FC = () => {
 
   return (
     <View style={styles.container}>
-      <Text>Enter your password to import your private key</Text>
+      <Text>Enter your password to import your private key:</Text>
 
       <Input
-        left={<LockIcon color={theme.colors.primary} />}
+        style={{height: 45}}
+        left={<LockIcon color={theme.colors.primary} width={16} height={16} />}
         value={password}
         onChangeText={setPassword}
         secureTextEntry
         placeholder="Password"
       />
 
-      <Button onPress={handlePassword}>
-        <Text>Enter password</Text>
-      </Button>
+      <View style={{alignItems: width >= 600 ? 'center' : undefined}}>
+        <Button onPress={handlePassword} small>
+          <Text>Enter password</Text>
+        </Button>
+      </View>
 
       {isPasswordOk && (
         <>
@@ -79,6 +85,7 @@ export const PrivateKeyImport: React.FC = () => {
           </Text>
           <Input
             value={privateKey}
+            style={{height: 45}}
             editable={false}
             right={
               <TouchableOpacity

--- a/apps/mobile/src/components/PrivateKeyImport/styles.ts
+++ b/apps/mobile/src/components/PrivateKeyImport/styles.ts
@@ -4,7 +4,7 @@ import {Spacing} from '../../styles';
 
 export default StyleSheet.create({
   container: {
-    alignItems: 'center',
+    gap: Spacing.small,
     // width: 100, // Set a fixed width for each item
     // height: 100, // Set a fixed height for each item
     // justifyContent: 'center',

--- a/apps/mobile/src/components/RelaysConfig/index.tsx
+++ b/apps/mobile/src/components/RelaysConfig/index.tsx
@@ -1,9 +1,9 @@
 import {useSettingsStore} from 'afk_nostr_sdk';
 import {AFK_RELAYS} from 'afk_nostr_sdk/src/utils/relay';
 import {useState} from 'react';
-import {View} from 'react-native';
+import {ScrollView, View} from 'react-native';
 
-import {useStyles} from '../../hooks';
+import {useStyles, useWindowDimensions} from '../../hooks';
 import {useToast} from '../../hooks/modals';
 import {Button} from '../Button';
 import {Input} from '../Input';
@@ -19,6 +19,8 @@ export const RelaysConfig: React.FC = () => {
   const [relaysUpdated, setRelaysUpdated] = useState<string[]>(relays);
   const [openUpdateMenu, setOpenUpdateMenu] = useState<boolean>(false);
   const [relayToAdd, setRelayToAdd] = useState<string | undefined>();
+
+  const {width} = useWindowDimensions();
 
   const removeRelay = (relay: string) => {
     const newRelays = relaysUpdated.filter((r) => r != relay);
@@ -39,15 +41,18 @@ export const RelaysConfig: React.FC = () => {
     /** @TODO add verify validity of the relayer */
 
     setRelaysUpdated(newRelays);
+    setRelayToAdd('');
   };
 
   const updateRelayToUsed = () => {
     setRelays(relaysUpdated);
+    showToast({type: 'success', title: 'Relays updated!'});
   };
 
   const resetDefault = () => {
     setRelays(AFK_DEFAULT_RELAYS);
     setRelaysUpdated(AFK_DEFAULT_RELAYS);
+    showToast({type: 'success', title: 'Relays have been reset to default'});
   };
 
   const handleOpenMenu = () => {
@@ -57,59 +62,113 @@ export const RelaysConfig: React.FC = () => {
   return (
     <View style={styles.container}>
       <View>
-        <Text style={styles.title}>AFK: All relays used</Text>
-        {RELAYS_USED?.map((r, i) => {
-          return (
-            <View style={styles.relayItem} key={i}>
-              <Text style={styles.text}>Relay: {r}</Text>
-            </View>
-          );
-        })}
+        <Text weight="bold" style={styles.title}>
+          AFK: All relays used
+        </Text>
       </View>
-      <View>
-        <Text>You can setup your relays</Text>
-        <Button style={{width: 'auto'}} onPress={handleOpenMenu}>
-          <Text>Open menu</Text>
-        </Button>
-      </View>
+
+      {!openUpdateMenu && (
+        <ScrollView
+          style={styles.codeBox}
+          showsVerticalScrollIndicator={true}
+          persistentScrollbar={true}
+        >
+          {RELAYS_USED?.map((r, i) => {
+            return (
+              <pre key={i} style={styles.codeBoxText}>
+                Relay: {r}
+              </pre>
+            );
+          })}
+        </ScrollView>
+      )}
+
+      {!openUpdateMenu && (
+        <View style={{alignItems: width >= 600 ? 'center' : undefined}}>
+          <Button onPress={handleOpenMenu} small>
+            <Text>Open menu to setup relays</Text>
+          </Button>
+        </View>
+      )}
 
       {openUpdateMenu && (
         <View>
-          {relaysUpdated?.map((r, i) => {
-            return (
-              <View style={styles.relayItem} key={i}>
-                <Text style={styles.text}>Relay: {r}</Text>
+          <View style={styles.editCodeBox}>
+            <ScrollView
+              style={styles.editCodeBoxRelays}
+              showsVerticalScrollIndicator={true}
+              persistentScrollbar={true}
+            >
+              {relaysUpdated?.map((r, i) => {
+                return (
+                  <pre key={i} style={styles.codeBoxText}>
+                    Relay: {r}
+                    <View style={{alignItems: 'flex-start'}}>
+                      <Button
+                        small
+                        style={{
+                          width: 'auto',
+                          paddingVertical: 6,
+                          paddingHorizontal: 12,
+                        }}
+                        textStyle={{
+                          fontSize: 12,
+                        }}
+                        onPress={() => removeRelay(r)}
+                        children="Remove"
+                      />
+                    </View>
+                  </pre>
+                );
+              })}
+            </ScrollView>
 
+            <Input
+              style={styles.relayInput}
+              inputStyle={{fontSize: 12}}
+              right={
                 <Button
+                  small
                   style={{
                     width: 'auto',
-                    marginHorizontal: 5,
+                    paddingVertical: 6,
+                    paddingHorizontal: 12,
                   }}
-                  onPress={() => removeRelay(r)}
-                >
-                  <Text>Remove</Text>
-                </Button>
-              </View>
-            );
-          })}
-          <Input
-            right={
-              <Button onPress={() => addRelay(relayToAdd)}>
-                <Text>Add this relay</Text>
+                  textStyle={{
+                    fontSize: 12,
+                  }}
+                  onPress={() => addRelay(relayToAdd)}
+                  children="+"
+                />
+              }
+              paddingRight={false}
+              value={relayToAdd}
+              onChangeText={setRelayToAdd}
+              placeholder="Relay"
+            />
+          </View>
+
+          <View
+            style={[styles.relayButtonContainer, {flexDirection: width >= 600 ? 'row' : 'column'}]}
+          >
+            <View style={{alignItems: width >= 600 ? 'center' : undefined}}>
+              <Button onPress={updateRelayToUsed} small>
+                <Text>Update my relay</Text>
               </Button>
-            }
-            value={relayToAdd}
-            onChangeText={setRelayToAdd}
-            placeholder="Relay"
-          />
+            </View>
 
-          <Button style={styles.button} onPress={updateRelayToUsed}>
-            <Text>Update my relay</Text>
-          </Button>
+            <View style={{alignItems: width >= 600 ? 'center' : undefined}}>
+              <Button onPress={resetDefault} small>
+                <Text>Reuse default AFK relay</Text>
+              </Button>
+            </View>
 
-          <Button style={styles.button} onPress={resetDefault}>
-            <Text>Reuse default AFK relay</Text>
-          </Button>
+            <View style={{alignItems: width >= 600 ? 'center' : undefined}}>
+              <Button onPress={handleOpenMenu} small>
+                <Text>Close Menu</Text>
+              </Button>
+            </View>
+          </View>
         </View>
       )}
     </View>

--- a/apps/mobile/src/components/RelaysConfig/styles.ts
+++ b/apps/mobile/src/components/RelaysConfig/styles.ts
@@ -1,23 +1,54 @@
 import {Spacing, ThemedStyleSheet} from '../../styles';
 export default ThemedStyleSheet((theme) => ({
   container: {
-    marginHorizontal: 10,
+    gap: Spacing.small,
+    paddingBottom: Spacing.normal,
+  },
+  codeBox: {
+    backgroundColor: theme.colors.codeBoxBackground,
+    padding: Spacing.medium,
+    borderRadius: 6,
+    fontFamily: 'Courier New, Courier, monospace',
+    color: theme.colors.buttonText,
+    maxHeight: 150,
+    overflow: 'hidden',
+    overflowX: 'auto',
+  },
+  editCodeBox: {
+    backgroundColor: theme.colors.codeBoxBackground,
+    padding: Spacing.medium,
+    borderRadius: 6,
+    fontFamily: 'Courier New, Courier, monospace',
+    color: theme.colors.buttonText,
+    overflowX: 'auto',
+  },
+  editCodeBoxRelays: {
+    maxHeight: 150,
+    overflow: 'hidden',
+  },
+  codeBoxText: {
+    // marginVertical and marginHorizontal does not support with <pre> tag
+    marginRight: 0,
+    marginLeft: 0,
+    marginTop: 6,
+    marginBottom: 6,
+    display: 'flex',
+    justifyContent: 'space-between',
     alignItems: 'center',
   },
-  relayItem: {
-    flex: 1,
-    flexDirection: 'row',
-    gap: 3,
-    alignItems: 'center',
+  relayInput: {
+    height: 30,
+    marginTop: Spacing.small,
   },
-  relayText: {
-    width: '100%',
+  relayButtonContainer: {
+    gap: Spacing.small,
+    justifyContent: 'center',
+    marginTop: Spacing.small,
   },
-  relayButton: {},
   title: {
+    textAlign: 'center',
     color: theme.colors.text,
-    fontSize: 24,
-    marginBottom: 4,
+    fontSize: 18,
   },
   text: {
     color: theme.colors.text,
@@ -34,9 +65,6 @@ export default ThemedStyleSheet((theme) => ({
     width: 35,
     height: 35,
     borderRadius: 15,
-  },
-  button: {
-    marginVertical: 5,
   },
 
   name: {

--- a/apps/mobile/src/screens/Settings/index.tsx
+++ b/apps/mobile/src/screens/Settings/index.tsx
@@ -1,7 +1,7 @@
 import {useAuth} from 'afk_nostr_sdk';
-import {Text, View} from 'react-native';
+import {View} from 'react-native';
 
-import {Button, Divider, Icon, IconButton} from '../../components';
+import {Button, Divider, Icon, IconButton, Text} from '../../components';
 import {HeaderScreen} from '../../components/HeaderScreen';
 import {PrivateKeyImport} from '../../components/PrivateKeyImport';
 import {RelaysConfig} from '../../components/RelaysConfig';
@@ -20,7 +20,7 @@ export const Settings: React.FC<SettingsScreenProps> = ({navigation}) => {
         left={
           <IconButton
             icon="ChevronLeftIcon"
-            size={24}
+            size={16}
             onPress={() => {
               navigation.navigate('Profile', {publicKey});
               // navigation.goBack
@@ -42,24 +42,28 @@ export const Settings: React.FC<SettingsScreenProps> = ({navigation}) => {
         />
       </Pressable> */}
 
-      <Button onPress={toggleTheme} style={{width: 'auto'}}>
-        <Icon
-          name={theme.dark ? 'SunIcon' : 'MoonIcon'}
-          size={24}
-          title="Switch theme"
-          onPress={toggleTheme}
-        />
-        <Text>Switch theme</Text>
-      </Button>
+      <View style={styles.content}>
+        <View style={styles.toggleThemeContainer}>
+          <Text>Switch theme</Text>
+          <Button onPress={toggleTheme} style={styles.themeButton}>
+            <Icon
+              style={styles.toggleIcon}
+              name={theme.dark ? 'SunIcon' : 'MoonIcon'}
+              size={24}
+              title="Switch theme"
+              onPress={toggleTheme}
+            />
+          </Button>
+        </View>
 
-      <Divider />
+        <Divider style={{marginVertical: 12}} />
 
-      {!isExtension && <PrivateKeyImport />}
-      <Divider />
+        {!isExtension && <PrivateKeyImport />}
 
-      <RelaysConfig></RelaysConfig>
+        <Divider style={{marginVertical: 12}} />
 
-      <Divider />
+        <RelaysConfig />
+      </View>
     </View>
   );
 };

--- a/apps/mobile/src/screens/Settings/styles.ts
+++ b/apps/mobile/src/screens/Settings/styles.ts
@@ -7,11 +7,31 @@ export default ThemedStyleSheet((theme) => ({
     padding: Spacing.pagePadding,
     color: theme.colors.text,
     gap: 3,
+    overflow: 'scroll',
+  },
+  toggleThemeContainer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  themeButton: {
+    width: Spacing.xxlarge,
+    height: Spacing.xxlarge,
+    borderRadius: Spacing.normal,
+    padding: 0,
+    paddingInline: 0,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  toggleIcon: {
+    position: 'relative',
+    top: 6,
+    left: 4,
   },
   content: {
     flex: 1,
     color: theme.colors.text,
-    padding: Spacing.medium,
+    paddingHorizontal: Spacing.medium,
   },
 
   backButton: {

--- a/apps/mobile/src/styles/Colors.tsx
+++ b/apps/mobile/src/styles/Colors.tsx
@@ -53,6 +53,8 @@ export const LightTheme = {
     buttonDisabledBackground: 'rgba(12, 12, 79, 0.1)',
     buttonDisabledText: 'rgba(20, 20, 44, 0.5)',
 
+    codeBoxBackground: '#f0e9dd',
+
     successLight: '#E4E9FA',
     successDark: '#6B87EC',
     errorLight: '#FFEDEB',
@@ -101,6 +103,8 @@ export const DarkTheme = {
     buttonText: '#FFFFFF',
     buttonDisabledBackground: 'rgba(150, 150, 150, 0.1)',
     buttonDisabledText: '#FFFFFF',
+
+    codeBoxBackground: '#373737',
 
     successLight: '#E4E9FA',
     successDark: '#6B87EC',


### PR DESCRIPTION
resolves #29 

- improved overall ui/ux of settings page
- improved spacing and sectioning
- improved sizes according to heirarchy
- added scroll to relays section with code snippet like ui
- improved web to mobile ui/ux (responsiveness)
- added colors

<img width="1180" alt="image" src="https://github.com/user-attachments/assets/b6c82725-9546-4980-9161-3a298bed522d">
<img width="1179" alt="image" src="https://github.com/user-attachments/assets/4132ca67-5c55-4659-aad8-e3525f0fdfeb">
<img width="1179" alt="image" src="https://github.com/user-attachments/assets/cc91b5b2-4405-48aa-bd50-ae5607c4dd47">
<img width="354" alt="image" src="https://github.com/user-attachments/assets/df00ff96-203d-4974-b4a1-f684fcacbeb1">
<img width="353" alt="image" src="https://github.com/user-attachments/assets/eec1bc51-a142-4054-b1e0-4bccd526866d">
<img width="355" alt="image" src="https://github.com/user-attachments/assets/64cf224c-54bb-45d0-9a7c-38ae1eea27d2">