### PR TITLE
Feat: add right sidebar nav desktop

### DIFF
--- a/apps/mobile/src/app/Router.tsx
+++ b/apps/mobile/src/app/Router.tsx
@@ -1,6 +1,6 @@
 import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
 import {createDrawerNavigator} from '@react-navigation/drawer';
-import {NavigationContainer} from '@react-navigation/native';
+import {NavigationContainer, useNavigation, useRoute} from '@react-navigation/native';
 import {createNativeStackNavigator} from '@react-navigation/native-stack';
 import {useAuth} from 'afk_nostr_sdk';
 import {useEffect, useMemo, useState} from 'react';
@@ -46,6 +46,7 @@ import {
   RootStackParams,
 } from '../types';
 import {retrievePublicKey} from '../utils/storage';
+import RightSidebar from '../components/RightSideBar';
 const DrawerStack = createDrawerNavigator<MainStackParams>();
 const RootStack = createNativeStackNavigator<RootStackParams>();
 const AuthStack = createDrawerNavigator<AuthStackParams>();
@@ -261,6 +262,17 @@ const MainNavigator: React.FC = () => {
 
   const theme = useTheme();
 
+  const FeedWithSidebar: React.FC = () => (
+    <View style={{ flexDirection: 'row', flex: 1 }}>
+      <View style={{ flex: 1 }}>
+        <Feed navigation={useNavigation()} route={useRoute()} />
+      </View>
+      <View style={{ width: 250, backgroundColor: theme.theme.colors.surface }}>
+        <RightSidebar />
+      </View>
+    </View>
+  );
+
   return (
     <DrawerStack.Navigator
       // screenOptions={{ headerShown: false }}
@@ -284,10 +296,11 @@ const MainNavigator: React.FC = () => {
         },
       })}
     >
+
       {!isDesktop ? (
         <DrawerStack.Screen name="Home" component={HomeBottomTabNavigator} />
       ) : (
-        <DrawerStack.Screen name="Feed" component={Feed} />
+        <DrawerStack.Screen name="Feed" component={FeedWithSidebar} />
       )}
       {isDesktop && (
         <DrawerStack.Screen

--- a/apps/mobile/src/app/Router.tsx
+++ b/apps/mobile/src/app/Router.tsx
@@ -198,8 +198,8 @@ const AuthNavigator: React.FC = () => {
       drawerContent={(props) => <AuthSidebar navigation={props?.navigation}></AuthSidebar>}
       screenOptions={({navigation}) => ({
         // headerShown:false,
-        header: () => <Navbar navigation={navigation} title="AFK" showLogo={true} />,
-        headerShown: false,
+        header: () => (!isDesktop ? <Navbar navigation={navigation} title="AFK" showLogo={true} /> : null),
+        headerShown: !isDesktop,
         headerStyle: {
           backgroundColor: theme.theme.colors.background,
         },
@@ -280,7 +280,8 @@ const MainNavigator: React.FC = () => {
       drawerContent={(props) => <Sidebar navigation={props?.navigation}></Sidebar>}
       screenOptions={({navigation}) => ({
         // headerShown:false,
-        header: () => <Navbar navigation={navigation} title="AFK" showLogo={true} />,
+        header: () => (!isDesktop ? <Navbar navigation={navigation} title="AFK" showLogo={true} /> : null),
+        headerShown: !isDesktop,
         headerStyle: {
           backgroundColor: theme.theme.colors.background,
         },

--- a/apps/mobile/src/components/RightSideBar/index.tsx
+++ b/apps/mobile/src/components/RightSideBar/index.tsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import { View, Text, TouchableOpacity, FlatList, ActivityIndicator } from 'react-native';
+import { useAuth, useProfile } from 'afk_nostr_sdk';
+import { useQueryAllCoins } from '../../hooks/launchpad/useQueryAllCoins';
+import { useStyles, useTheme } from '../../hooks';
+import stylesheet from './styles';
+import { TokenLaunchDetail } from '../../components/pump/TokenLaunchDetail';
+import { TokenLaunchInterface } from '../../types/keys';
+
+const tabs = ['Trending', 'Quests'];
+
+const RightSidebar = () => {
+  const { theme } = useTheme();
+  const styles = useStyles(stylesheet);
+  const [activeTab, setActiveTab] = useState(tabs[0]);
+
+  const publicKey = useAuth((state) => state.publicKey);
+  const { data: profile } = useProfile({ publicKey });
+
+  const { data: coins, isLoading, error } = useQueryAllCoins();
+
+  const handleTabChange = (tab: string) => {
+    setActiveTab(tab);
+  };
+
+  const renderListItem = ({ item }: { item: TokenLaunchInterface }) => (
+    <View style={styles.itemContainer}>
+      <TokenLaunchDetail launch={item} isViewDetailDisabled={true} />
+    </View>
+  );
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.tabContainer}>
+        {tabs.map((tab) => (
+          <TouchableOpacity
+            key={tab}
+            style={[styles.tab, activeTab === tab && styles.activeTab]}
+            onPress={() => handleTabChange(tab)}
+          >
+            <Text style={styles.tabText}>{tab}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+      <View>
+        {activeTab === 'Trending' && (
+          <>
+            {isLoading ? (
+              <ActivityIndicator size="large" color={theme.colors.text} />
+            ) : error ? (
+              <Text style={{ color: theme.colors.text }}>Failed to load coins</Text>
+            ) : (
+              <FlatList
+                data={coins}
+                renderItem={renderListItem}
+                keyExtractor={(item) => item.token_address.toString()}
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                ListEmptyComponent={<Text style={{ color: theme.colors.text }}>No coins available</Text>}
+                ItemSeparatorComponent={() => <View style={styles.itemSeparator} />}
+              />
+            )}
+          </>
+        )}
+        {activeTab === 'Quests' && (
+          <>
+            {profile ? (
+              <Text style={{ color: theme.colors.text }}>NIP05: {profile.nip05}</Text>
+            ) : (
+              <Text style={{ color: theme.colors.text }}>...</Text>
+            )}
+          </>
+        )}
+      </View>
+    </View>
+  );
+};
+
+export default RightSidebar;

--- a/apps/mobile/src/components/RightSideBar/styles.ts
+++ b/apps/mobile/src/components/RightSideBar/styles.ts
@@ -8,6 +8,8 @@ export default ThemedStyleSheet((theme) => ({
     padding: 20,
     gap: 1,
     color: theme.colors.text,
+    borderLeftWidth: 1,
+    borderLeftColor: theme.colors.sidebarDivider,
   },
   tabContainer: {
     flexDirection: 'row',

--- a/apps/mobile/src/components/RightSideBar/styles.ts
+++ b/apps/mobile/src/components/RightSideBar/styles.ts
@@ -1,0 +1,45 @@
+import { Spacing, ThemedStyleSheet } from '../../styles';
+
+export default ThemedStyleSheet((theme) => ({
+  container: {
+    width: '100%',
+    height: '100%',
+    backgroundColor: theme.colors.background,
+    padding: 20,
+    gap: 1,
+    color: theme.colors.text,
+  },
+  tabContainer: {
+    flexDirection: 'row',
+    marginBottom: 16,
+  },
+  tab: {
+    flex: 1,
+    paddingVertical: Spacing.small,
+    paddingHorizontal: Spacing.medium,
+    backgroundColor: theme.colors.surface,
+    borderBottomWidth: 1,
+    borderColor: theme.colors.divider,
+  },
+  activeTab: {
+    backgroundColor: theme.colors.divider,
+  },
+  tabText: {
+    fontSize: 18,
+    color: theme.colors.text,
+  },
+  content: {
+    color: theme.colors.text,
+    padding: Spacing.medium,
+  },
+  itemContainer: {
+    maxWidth: 170,
+  },
+  itemText: {
+    color: theme.colors.text,
+    marginBottom: Spacing.small,
+  },
+  itemSeparator: {
+    width: Spacing.medium,
+  },
+}));

--- a/apps/mobile/src/components/search/styles.ts
+++ b/apps/mobile/src/components/search/styles.ts
@@ -5,19 +5,19 @@ export default ThemedStyleSheet((theme) => ({
     flexDirection: 'row',
     alignItems: 'center',
     // backgroundColor: '#f0f0f0',
-    background: theme.colors.background,
+    backgroundColor: theme.colors.background,
     color: theme.colors.text,
     borderRadius: 20,
     marginHorizontal: 10,
     paddingHorizontal: 10,
-    paddingVertical: 5,
+    paddingVertical: 20,
   },
   iconContainer: {
     marginRight: 10,
   },
   input: {
     flex: 1,
-    background: theme.colors.background,
+    backgroundColor: theme.colors.background,
     borderColor: theme.colors.background,
 
     color: theme.colors.text,

--- a/apps/mobile/src/modules/Layout/sidebar/index.tsx
+++ b/apps/mobile/src/modules/Layout/sidebar/index.tsx
@@ -1,7 +1,7 @@
 // import { useAuth } from '../../../store/auth';
 import {useAuth, useNostrContext} from 'afk_nostr_sdk';
 import React, {useEffect, useMemo} from 'react';
-import {Pressable, Text, View} from 'react-native';
+import {Pressable, Text, View, Image} from 'react-native';
 
 import {Icon} from '../../../components/Icon';
 import {useStyles, useTheme, useWindowDimensions} from '../../../hooks';
@@ -60,7 +60,10 @@ const Sidebar = ({navigation}: SidebarInterface) => {
 
   return (
     <View style={styles.sidebar}>
-      <Text style={styles.sidebarText}>AFK</Text>
+      <View style={styles.rowContainer}>
+        { isDesktop && <Image style={styles.logo} source={require('./../../../assets/pepe-logo.png')} />}
+        <Text style={styles.sidebarText}>AFK</Text>
+      </View>
       {/* 
             <Text style={[styles.item]}>
                 Launchpad

--- a/apps/mobile/src/modules/Layout/sidebar/styles.ts
+++ b/apps/mobile/src/modules/Layout/sidebar/styles.ts
@@ -16,6 +16,12 @@ export default ThemedStyleSheet((theme) => ({
     flexDirection: 'row',
     alignItems: 'center',
   },
+  rowContainer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 30,
+  },
   logo: {
     width: 40,
     height: 40,

--- a/apps/mobile/src/screens/Tips/styles.ts
+++ b/apps/mobile/src/screens/Tips/styles.ts
@@ -4,6 +4,8 @@ export default ThemedStyleSheet((theme) => ({
   container: {
     flex: 1,
     backgroundColor: theme.colors.background,
+    paddingVertical: Spacing.xxxsmall,
+    paddingHorizontal: Spacing.normal,
   },
 
   flatListContent: {

--- a/apps/mobile/src/styles/Colors.tsx
+++ b/apps/mobile/src/styles/Colors.tsx
@@ -45,6 +45,7 @@ export const LightTheme = {
     onSecondary: '#FFFFFF',
 
     divider: '#e4e4e7',
+    sidebarDivider: '#e4e4e7',
 
     bottomBarActive: '#14142C',
     bottomBarInactive: 'rgba(30, 47, 61, 0.5)',
@@ -103,6 +104,7 @@ export const DarkTheme = {
     onSecondary: '#FFFFFF',
 
     divider: '#1b1b18',
+    sidebarDivider: '#FFFFFF',
 
     bottomBarActive: '#8F979E',
     bottomBarInactive: 'rgb(105,105,105, 0.5)',


### PR DESCRIPTION
### Description 

- This solves #85  

Add Desktop right sidebar for Trending quests etc

### Implementation 

 - Only available in Desktop 
 - Create a RightSidebar screen, some implementation are in the layout already
 - Add TABS for this Right bar: Trending, Quests.
 - Add some data as examples using Nostr hooks, Launchpad hooks etc
 - Add Right sidebar to the Router.ts and navigator for Main, Degen etc
 - Add this in the Router.ts component maybe (some impl have been try to add two DrawerNavigator)

### Screenshots

Demo

https://github.com/user-attachments/assets/d036b0cd-70ca-4f79-a016-93f542ef792f

Desktop

![image](https://github.com/user-attachments/assets/b39c6e8d-9a4c-4cbc-82f5-66271667e3d8)

Mobile

![image](https://github.com/user-attachments/assets/450bfe30-7281-49f9-b3c2-cc54da900878)

