### PR TITLE
Nostr deposit tip with Solidity

### DIFF
--- a/onchain/cairo/src/social/deposit.cairo
+++ b/onchain/cairo/src/social/deposit.cairo
@@ -195,16 +195,16 @@ pub mod DepositEscrow {
             if (!recipient.is_zero()) {
                 let erc20 = IERC20Dispatcher { contract_address: token_address };
                 erc20.transfer_from(get_caller_address(), recipient, amount);
-                self
-                    .emit(
-                        TransferEvent {
-                            sender: get_caller_address(),
-                            nostr_recipient,
-                            starknet_recipient: recipient,
-                            amount: amount,
-                            token_address: token_address
-                        }
-                    );
+                // self
+                //     .emit(
+                //         TransferEvent {
+                //             sender: sender_address,
+                //             nostr_recipient,
+                //             starknet_recipient: recipient,
+                //             amount: amount,
+                //             token_address: token_address
+                //         }
+                //     );
                 return DepositResult::Transfer(recipient);
             }
 
@@ -226,16 +226,16 @@ pub mod DepositEscrow {
                         ttl: get_block_timestamp() + timelock
                     }
                 );
-            self
-                .emit(
-                    DepositEvent {
-                        deposit_id,
-                        sender: get_caller_address(),
-                        nostr_recipient,
-                        amount: amount,
-                        token_address: token_address
-                    }
-                );
+            // self
+            //     .emit(
+            //         DepositEvent {
+            //             deposit_id,
+            //             sender: sender_address,
+            //             nostr_recipient,
+            //             amount: amount,
+            //             token_address: token_address
+            //         }
+            //     );
 
             DepositResult::Deposit(deposit_id)
         }
@@ -252,21 +252,20 @@ pub mod DepositEscrow {
 
             erc20.transfer(get_caller_address(), deposit.amount);
             self.deposits.write(deposit_id, Default::default());
-            self
-                .emit(
-                    CancelEvent {
-                        deposit_id,
-                        sender: get_caller_address(),
-                        nostr_recipient: deposit.recipient,
-                        amount: deposit.amount,
-                        token_address: deposit.token_address
-                    }
-                );
+        // self
+        //     .emit(
+        //         CancelEvent {
+        //             deposit_id,
+        //             sender: get_caller_address(),
+        //             nostr_recipient: deposit.recipient,
+        //             amount: deposit.amount,
+        //             token_address: deposit.token_address
+        //         }
+        //     );
         }
 
         fn claim(ref self: ContractState, request: SocialRequest<Claim>, gas_amount: u256) {
             let claim = @request.content;
-
             let deposit = self.deposits.read(*claim.deposit_id);
             assert!(deposit != Default::default(), "can't find deposit");
             assert!(request.public_key == deposit.recipient, "invalid recipient");
@@ -281,23 +280,22 @@ pub mod DepositEscrow {
 
             // TODO: swap if necessary
             assert!(deposit.token_address == *claim.gas_token_address, "invalid gas_token");
-            assert!(gas_amount <= *claim.gas_amount, "gas_amount to big");
+            assert!(gas_amount <= *claim.gas_amount, "gas_amount too big");
             let gas_token = IERC20Dispatcher { contract_address: *claim.gas_token_address };
             gas_token.transfer(get_caller_address(), gas_amount);
-
-            self
-                .emit(
-                    ClaimEvent {
-                        deposit_id: *claim.deposit_id,
-                        sender: get_caller_address(),
-                        nostr_recipient: request.public_key,
-                        amount: deposit.amount,
-                        starknet_recipient: *claim.starknet_recipient,
-                        token_address: deposit.token_address,
-                        gas_token_address: *claim.gas_token_address,
-                        gas_amount: *claim.gas_amount
-                    }
-                );
+        // self
+        //     .emit(
+        //         ClaimEvent {
+        //             deposit_id: *claim.deposit_id,
+        //             sender: get_caller_address(),
+        //             nostr_recipient: request.public_key,
+        //             amount: deposit.amount,
+        //             starknet_recipient: *claim.starknet_recipient,
+        //             token_address: deposit.token_address,
+        //             gas_token_address: *claim.gas_token_address,
+        //             gas_amount: *claim.gas_amount
+        //         }
+        //     );
         }
     }
 }

--- a/onchain/solidity_contracts/src/nostr/DepositEscrowNostr.sol
+++ b/onchain/solidity_contracts/src/nostr/DepositEscrowNostr.sol
@@ -2,6 +2,7 @@
 pragma solidity >=0.8.0;
 
 import {CairoLib} from "kakarot-lib/CairoLib.sol";
+import {DualVMToken} from "../examples/DualVmToken.sol";
 
 using CairoLib for uint256;
 
@@ -13,82 +14,232 @@ contract DepositEscrowNostr {
     /// @dev The address of the starknet token to call
     uint256 immutable kakarot;
 
-    mapping (address => uint) name;
-    mapping (address => Deposit) depositUsers;
+    // mapping (address => uint) name;
+    // mapping (address => Deposit) depositUsers;
+    mapping (address => uint256) evmToStarknetAddresses;
+    mapping (uint256 => address) starknetToEvmAddresses;
 
-
-    struct SocialRequestClaim {
-        uint256 public_key;
-        uint64 created_at;
-        uint16 kind;
-        bytes tags;
-        Content content;
-        Signature sig;
-    }
-    
     struct Content {
-        bytes31 deposit_id;
-        uint256 starknet_recipient;
-        uint256 gas_token_address;
-        uint256 gas_amount;
+        uint256 depositId;
+        address recipient;
+        address gasTokenAddress;
+        uint256 gasAmount;
     }
+
     struct Signature {
         uint256 r;
         uint256 s;
     }
 
-
-    struct Deposit {
-        uint256 deposit;
-        uint256 withdraw;
-        uint256 nostrAddress;
-        address owner;
+    struct SocialRequestClaim {
+        uint256 publicKey;
+        uint64 createdAt;
+        uint16 kind;
+        bytes tags;
+        Content content;
+        Signature sig;
     }
 
-    constructor(uint256 _kakarot,
-        uint256 _depositAddress) {
-            kakarot = _kakarot;
-            depositAddress = _depositAddress;
+    struct Deposit {
+        address sender;
+        uint256 amount;
+        address tokenAddress;
+        uint256 nostrRecipient;
+        uint64 ttl;
+    }
+
+    enum DepositResult {
+        Transfer,
+        Deposit
+    }
+
+    event TransferEvent(
+        address indexed sender,
+        uint256 indexed nostrRecipient,
+        address indexed recipient,
+        uint256 amount,
+        address tokenAddress
+    );
+
+    event DepositEvent(
+        uint256 indexed depositId,
+        address indexed sender,
+        uint256 indexed nostrRecipient,
+        uint256 amount,
+        address tokenAddress
+    );
+
+    event CancelEvent(
+        uint256 indexed depositId,
+        address indexed sender,
+        uint256 indexed nostrRecipient,
+        uint256 amount,
+        address tokenAddress
+    );
+
+    event ClaimEvent(
+        uint256 indexed depositId,
+        address indexed sender,
+        uint256 indexed nostrRecipient,
+        address recipient,
+        uint256 amount,
+        address tokenAddress,
+        address gasTokenAddress,
+        uint256 gasAmount
+    );
+
+    constructor(uint256 _kakarot, uint256 _depositAddress) {
+        kakarot = _kakarot;
+        depositAddress = _depositAddress;
+    }
+
+    function bytesFeltToUint256(bytes calldata b) internal pure returns (uint256) {
+        require(b.length <= 31, "Byte array should be no longer than 31 bytes");
+        return abi.decode(abi.encodePacked(new bytes(32 - b.length), b), (uint256));
+    }
+
+    function getDeposit(uint256 depositId) public view returns(Deposit memory) {
+        uint256[] memory depositCallData = new uint256[](1);
+        depositCallData[0] = depositId;
+        (
+            uint256 sender,
+            uint128 amountLow, uint128 amountHigh,
+            uint256 tokenAddress,
+            uint128 nostrRecipientLow, uint128 nostrRecipientHigh,
+            uint64 ttl
+        ) = abi.decode(
+            depositAddress.staticcallCairo("get_deposit", depositCallData),
+            (uint256, uint128, uint128, uint256, uint128, uint128, uint64)
+        );
+        return Deposit({
+            sender: starknetToEvmAddresses[sender],
+            amount: uint256(amountLow) + (uint256(amountHigh) << 128),
+            tokenAddress: starknetToEvmAddresses[tokenAddress],
+            nostrRecipient: uint256(nostrRecipientLow) + (uint256(nostrRecipientHigh) << 128),
+            ttl: ttl
+        });
     }
 
     function depositTo(
         uint256 amount,
         address tokenAddress,
-        uint256 nostrAddress,
-        uint64 timelock) public returns(uint256) {
-
+        uint256 nostrRecipient,
+        uint64 timelock
+    ) public returns(DepositResult, uint256) {
+        // Get sender address
+        if (evmToStarknetAddresses[msg.sender] == 0) {
+            uint256[] memory kakarotCallData = new uint256[](1);
+            kakarotCallData[0] = uint256(uint160(msg.sender));
+            uint256 senderStarknetAddress = abi.decode(
+                kakarot.staticcallCairo("compute_starknet_address", kakarotCallData),
+                (uint256)
+            );
+            evmToStarknetAddresses[msg.sender] = senderStarknetAddress;
+            starknetToEvmAddresses[senderStarknetAddress] = msg.sender;
+        }
         // Get token address
-        uint256[] memory kakarotCallData = new uint256[](1);
-        kakarotCallData[0] = uint256(uint160(tokenAddress));
-
-        uint256 tokenStarknetAddress =
-            abi.decode(kakarot.staticcallCairo("compute_starknet_address", kakarotCallData), (uint256));
-
-        // // Split amount in [low, high]
-        uint128 amountLow = uint128(amount);
-        uint128 amountHigh = uint128(amount >> 128);
-
-                // Split amount in [low, high]
-        uint128 nostrAddressLow = uint128(nostrAddress);
-        uint128 nostrAddressHigh = uint128(nostrAddress >> 128);
+        if(evmToStarknetAddresses[tokenAddress] == 0) {
+            uint256 tokenStarknetAddress = DualVMToken(tokenAddress).starknetTokenAddress();
+            evmToStarknetAddresses[tokenAddress] = tokenStarknetAddress;
+            starknetToEvmAddresses[tokenStarknetAddress] = tokenAddress;
+        }
 
         uint256[] memory depositCallData = new uint256[](6);
-        depositCallData[0] = amountLow;
-        depositCallData[1] = amountHigh;
-        depositCallData[2] = tokenStarknetAddress;
-        depositCallData[3] = uint(nostrAddressLow);
-        depositCallData[4] = uint(nostrAddressHigh);
-        depositCallData[5] = uint(timelock);
-        bytes memory returnData = depositAddress.staticcallCairo("deposit", depositCallData);
-        return abi.decode(returnData, (uint256));
-        // return tokenStarknetAddress;
-
-
+        // Split amount in [low, high]
+        depositCallData[0] = uint128(amount);
+        depositCallData[1] = uint128(amount >> 128);
+        depositCallData[2] = evmToStarknetAddresses[tokenAddress];
+        // Split recipient in [low, high]
+        depositCallData[3] = uint128(nostrRecipient);
+        depositCallData[4] = uint128(nostrRecipient >> 128);
+        depositCallData[5] = timelock;
+        bytes memory returnData = depositAddress.delegatecallCairo("deposit", depositCallData);
+        (DepositResult depositResultType, uint256 depositResultPayload) =
+            abi.decode(returnData, (DepositResult, uint256));
+        if (depositResultType == DepositResult.Transfer) {
+            emit TransferEvent(
+                msg.sender,
+                nostrRecipient,
+                starknetToEvmAddresses[depositResultPayload],
+                amount,
+                tokenAddress
+            );
+        } else if (depositResultType == DepositResult.Deposit) {
+            emit DepositEvent(
+                depositResultPayload,
+                msg.sender,
+                nostrRecipient,
+                amount,
+                tokenAddress
+            );
+        }
+        return (depositResultType, depositResultPayload);
     }
 
-    function claim(SocialRequestClaim memory request) public {
-        
+    function cancel(uint256 depositId) public {
+        Deposit memory deposit = getDeposit(depositId);
+        uint256[] memory depositCallData = new uint256[](1);
+        depositCallData[0] = depositId;
+        depositAddress.delegatecallCairo("cancel", depositCallData);
+        emit CancelEvent(
+            depositId,
+            deposit.sender,
+            deposit.nostrRecipient,
+            deposit.amount,
+            deposit.tokenAddress
+        );
     }
 
+    function claim(SocialRequestClaim calldata request, uint256 gasAmount) public {
+        Deposit memory deposit = getDeposit(request.content.depositId);
+        // Get recipient address
+        if (evmToStarknetAddresses[request.content.recipient] == 0) {
+            uint256[] memory kakarotCallData = new uint256[](1);
+            kakarotCallData[0] = uint256(uint160(request.content.recipient));
+            uint256 recipientStarknetAddress = abi.decode(
+                kakarot.staticcallCairo("compute_starknet_address", kakarotCallData),
+                (uint256)
+            );
+            evmToStarknetAddresses[request.content.recipient] = recipientStarknetAddress;
+            starknetToEvmAddresses[recipientStarknetAddress] = request.content.recipient;
+        }
+        // Get token address
+        if(evmToStarknetAddresses[request.content.gasTokenAddress] == 0) {
+            uint256 tokenStarknetAddress =
+                DualVMToken(request.content.gasTokenAddress).starknetTokenAddress();
+            evmToStarknetAddresses[request.content.gasTokenAddress] = tokenStarknetAddress;
+            starknetToEvmAddresses[tokenStarknetAddress] = request.content.gasTokenAddress;
+        }
+        uint256[] memory depositCallData = new uint256[](18);
+        depositCallData[0] = uint128(request.publicKey);
+        depositCallData[1] = uint128(request.publicKey >> 128);
+        depositCallData[2] = request.createdAt;
+        depositCallData[3] = request.kind;
+        depositCallData[4] = 0;
+        depositCallData[5] = bytesFeltToUint256(request.tags);
+        depositCallData[6] = request.tags.length;
+        depositCallData[7] = request.content.depositId;
+        depositCallData[8] = evmToStarknetAddresses[request.content.recipient];
+        depositCallData[9] = evmToStarknetAddresses[request.content.gasTokenAddress];
+        depositCallData[10] = uint128(request.content.gasAmount);
+        depositCallData[11] = uint128(request.content.gasAmount >> 128);
+        depositCallData[12] = uint128(request.sig.r);
+        depositCallData[13] = uint128(request.sig.r >> 128);
+        depositCallData[14] = uint128(request.sig.s);
+        depositCallData[15] = uint128(request.sig.s >> 128);
+        depositCallData[16] = uint128(gasAmount);
+        depositCallData[17] = uint128(gasAmount >> 128);
+        depositAddress.delegatecallCairo("claim", depositCallData);
+        emit ClaimEvent(
+            request.content.depositId,
+            msg.sender,
+            request.publicKey,
+            request.content.recipient,
+            deposit.amount,
+            deposit.tokenAddress,
+            request.content.gasTokenAddress,
+            request.content.gasAmount
+        );
+    }
     
 }

--- a/onchain/tests/TipNostr.test.ts
+++ b/onchain/tests/TipNostr.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import hre from "hardhat";
 import { ethers } from "hardhat";
-import { parseEther, type Contract as EthContract, type Signer } from "ethers";
+import { EventLog, parseEther, ZeroAddress } from "ethers";
 import type { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
 import "@nomicfoundation/hardhat-ethers";
 import {
@@ -10,20 +10,15 @@ import {
   getTestProvider,
   getTestAccount,
 } from "../scripts/config";
-import dotenv from "dotenv";
 import {
   cairo,
-  constants,
   DeclareDeployUDCResponse,
   Contract as StarknetContract,
 } from "starknet";
-import {
-  // TipNostr,
-  DepositEscrowNostr,
-  DualVMToken
-} from "../typechain-types";
-import { TOKENS_ADDRESS, ACCOUNT_TEST_PROFILE } from "common";
-import { finalizeEvent } from "nostr-tools"
+import { DepositEscrowNostr, DualVMToken } from "../typechain-types";
+import { ACCOUNT_TEST_PROFILE } from "common";
+import { finalizeEvent } from "nostr-tools";
+import dotenv from "dotenv";
 dotenv.config();
 
 const KAKAROT_ADDRESS = process.env.KAKAROT_ADDRESS || "";
@@ -35,7 +30,7 @@ describe("TipNostr Test", function () {
   this.timeout(0);
   let tipNostr: DepositEscrowNostr;
   let owner: HardhatEthersSigner;
-  let ownerStarknet: string;
+  let ownerStarknet: bigint;
   let addr1: HardhatEthersSigner;
   let addr2: HardhatEthersSigner;
 
@@ -53,13 +48,59 @@ describe("TipNostr Test", function () {
   let ddToken: DeclareDeployUDCResponse;
   let starknetDeposit: StarknetContract;
 
-  const TOKEN_QUOTE_ADDRESS = TOKENS_ADDRESS[constants.StarknetChainId.SN_SEPOLIA].ETH;
-  const TOKEN_QUOTE_ADDRESS_KAKAROT = TOKENS_ADDRESS.KAKAROT[constants.StarknetChainId.SN_SEPOLIA].ETH;
+  const computeStarknetAddress = async (evmAddress: string) => {
+    const result = await account.callContract({
+      contractAddress: KAKAROT_ADDRESS,
+      calldata: [evmAddress],
+      entrypoint: "compute_starknet_address",
+    });
+    return BigInt(result[0]);
+  };
 
-  // Nostr account
-  let privateKeyAlice = ACCOUNT_TEST_PROFILE?.alice?.nostrPrivateKey as any;
-  const alicePublicKey = ACCOUNT_TEST_PROFILE?.alice?.nostrPublicKey;
-  let alicePublicKeyUint256 = BigInt("0x" + alicePublicKey)
+  const claimRequest = async (
+    recipient: HardhatEthersSigner,
+    nostrPublicKey: string,
+    nostrPrivateKey: string,
+    depositId: bigint,
+    gasAmount: bigint
+  ) => {
+    // Start claim with Nostr event
+    const recipientStarknetAddress = await computeStarknetAddress(
+      recipient.address
+    );
+    const content = `claim: ${depositId},${recipientStarknetAddress},${BigInt(
+      starknetToken.address
+    ).toString()},${gasAmount}`;
+    const timestamp = Date.now();
+    //let privateKeyAlice = ACCOUNT_TEST_PROFILE?.alice?.nostrPrivateKey as any;
+    //let privateKey = privateKeyAlice;
+    // Sign Nostr event
+    const event = finalizeEvent(
+      {
+        kind: 1,
+        tags: [],
+        content,
+        created_at: timestamp,
+      },
+      ethers.getBytes(`0x${nostrPrivateKey}`)
+    );
+    return {
+      publicKey: `0x${nostrPublicKey}`,
+      createdAt: event.created_at,
+      kind: event.kind,
+      tags: ethers.toUtf8Bytes("[]"), // tags
+      content: {
+        depositId,
+        recipient: recipient.address,
+        gasTokenAddress: await dualVMToken.getAddress(),
+        gasAmount,
+      },
+      sig: {
+        r: `0x${event.sig.slice(0, event.sig.length / 2)}`,
+        s: `0x${event.sig.slice(event.sig.length / 2)}`,
+      },
+    };
+  };
 
   this.beforeAll(async function () {
     try {
@@ -67,13 +108,7 @@ describe("TipNostr Test", function () {
 
       // Pre-compute the StarkNet address of the ETH-side owner
       // to mint him the initial supply of the token
-      ownerStarknet = (
-        await account.callContract({
-          contractAddress: KAKAROT_ADDRESS,
-          calldata: [owner.address],
-          entrypoint: "compute_starknet_address",
-        })
-      )[0];
+      ownerStarknet = await computeStarknetAddress(owner.address);
 
       // Send eth to addr1 and addr2, effectively deploying the underlying EOA accounts
       await owner
@@ -89,10 +124,9 @@ describe("TipNostr Test", function () {
         })
         .then((tx) => tx.wait());
 
-
       /** Deploy the contract */
       // Deploy the starknetToken
-      console.log("deploy token class hash")
+      console.log("deploy token class hash");
       ddToken = await account.declareAndDeploy({
         contract: starknetTokenSierra,
         casm: starknetTokenCasm,
@@ -101,7 +135,8 @@ describe("TipNostr Test", function () {
           cairo.felt("TEST"),
           cairo.uint256(100_000_000),
           ownerStarknet,
-          18],
+          18,
+        ],
       });
       starknetToken = new StarknetContract(
         starknetTokenSierra.abi,
@@ -115,11 +150,10 @@ describe("TipNostr Test", function () {
       );
       dualVMToken = await DualVMTokenFactory.deploy(
         KAKAROT_ADDRESS,
-        TOKEN_QUOTE_ADDRESS
-        // starknetToken.address
+        starknetToken.address
       ).then((c) => c.waitForDeployment());
 
-      // Whitelist the Duam Token contract to call Cairo contracts
+      // Whitelist the Dual Token contract to call Cairo contracts
       await account.execute([
         {
           contractAddress: KAKAROT_ADDRESS,
@@ -129,7 +163,7 @@ describe("TipNostr Test", function () {
       ]);
 
       // Deploy the starknetDeposit
-      console.log("deploy deposit escrow")
+      console.log("deploy deposit escrow");
 
       dd = await account.declareAndDeploy({
         contract: starknetDepositEscrowSierra,
@@ -142,17 +176,15 @@ describe("TipNostr Test", function () {
         dd.deploy.contract_address,
         account
       );
-
       // Deploy the tipNostr contract
-      console.log("deploy solidity tip nostr")
+      console.log("deploy solidity tip nostr");
 
       const tipNostrFactory = await hre.ethers.getContractFactory(
         "DepositEscrowNostr"
       );
-      tipNostr = await tipNostrFactory.deploy(
-        KAKAROT_ADDRESS,
-        starknetDeposit.address
-      ).then((c) => c.waitForDeployment());
+      tipNostr = await tipNostrFactory
+        .deploy(KAKAROT_ADDRESS, starknetDeposit.address)
+        .then((c) => c.waitForDeployment());
 
       // Whitelist the DualVMLaunchpad contract to call Cairo contracts
       await account.execute([
@@ -163,129 +195,282 @@ describe("TipNostr Test", function () {
         },
       ]);
 
+      // fund addr1 with the DualVmToken
+      await dualVMToken
+        .connect(owner)
+        .transfer(addr1.address, 1000)
+        .then((tx) => tx.wait());
     } catch (e) {
-      console.log("error before all", e)
+      console.error("error before all", e);
     }
+  });
 
-
+  describe("getDeposit", function () {
+    it("should retrieve a deposit", async function () {
+      const depositAmount = 100n;
+      await dualVMToken
+        .starknetApprove(starknetDeposit.address, depositAmount)
+        .then((tx) => tx.wait());
+      const result = await tipNostr
+        .depositTo(
+          depositAmount,
+          await dualVMToken.getAddress(),
+          BigInt(`0x${ACCOUNT_TEST_PROFILE.alice.nostrPublicKey}`),
+          0
+        )
+        .then((tx) => tx.wait());
+      if (!result) {
+        expect.fail("Tx receipt not found");
+      }
+      const [depositEvent] = result.logs as EventLog[];
+      const { depositId } = depositEvent.args.toObject() as {
+        depositId: bigint;
+      };
+      const starknetDepositResult = await starknetDeposit.call("get_deposit", [
+        depositId,
+      ]);
+      const depositResult = await tipNostr.getDeposit(depositId);
+      expect(starknetDepositResult).to.include({
+        sender: await computeStarknetAddress(depositResult.sender),
+        amount: depositResult.amount,
+        token_address: BigInt(starknetToken.address),
+        recipient: depositResult.nostrRecipient,
+        ttl: depositResult.ttl,
+      });
+    });
+    it("should return the default deposit when depositId is invalid", async function () {
+      const { sender, amount, tokenAddress, nostrRecipient, ttl } =
+        await tipNostr.getDeposit(0n);
+      expect({ sender, amount, tokenAddress, nostrRecipient, ttl }).to.include({
+        sender: ZeroAddress,
+        amount: 0n,
+        tokenAddress: ZeroAddress,
+        nostrRecipient: 0n,
+        ttl: 0n,
+      });
+    });
   });
 
   describe("depositTo", function () {
-    it("Should deposit to a Nostr user", async function () {
-
+    it("should deposit to the escrow", async function () {
+      const depositAmount = 100n;
       await dualVMToken
-        .connect(addr1)
-        .approve(addr2.address, 100)
+        .starknetApprove(starknetDeposit.address, depositAmount)
         .then((tx) => tx.wait());
-      expect(
-        await dualVMToken.allowance(await addr1.address, addr2.address)
-      ).to.equal(100);
-
-      await tipNostr
-        .connect(addr1)
+      const senderBalanceBeforeDeposit = await dualVMToken.balanceOf(
+        owner.address
+      );
+      await expect(
+        tipNostr
+          .depositTo(
+            depositAmount,
+            await dualVMToken.getAddress(),
+            BigInt(`0x${ACCOUNT_TEST_PROFILE.alice.nostrPublicKey}`),
+            0n
+          )
+          .then((tx) => tx.wait())
+      )
+        .to.emit(tipNostr, "DepositEvent")
+        .withArgs(
+          2n,
+          owner.address,
+          BigInt(`0x${ACCOUNT_TEST_PROFILE.alice.nostrPublicKey}`),
+          depositAmount,
+          await dualVMToken.getAddress()
+        );
+      const senderBalanceAfterDeposit = await dualVMToken.balanceOf(
+        owner.address
+      );
+      expect(senderBalanceBeforeDeposit - depositAmount).to.equal(
+        senderBalanceAfterDeposit,
+        "sender amount to deposit not send"
+      );
+      // expect(
+      //   await dualVMToken.starknetBalanceOf(starknetDeposit.address)
+      // ).to.equal(amount, "escrow after deposit != amount");
+    });
+    it("should transfer directly to the recipient after initial successful claim", async function () {
+      const depositAmount = 100n;
+      const gasAmount = 0n;
+      await dualVMToken
+        .starknetApprove(starknetDeposit.address, depositAmount * 2n)
+        .then((tx) => tx.wait());
+      const result = await tipNostr
         .depositTo(
-          1n,
-          // await dualVMToken.getAddress(),
-          TOKEN_QUOTE_ADDRESS_KAKAROT,
-          alicePublicKeyUint256,
-          0
+          depositAmount,
+          await dualVMToken.getAddress(),
+          BigInt(`0x${ACCOUNT_TEST_PROFILE.alice.nostrPublicKey}`),
+          0n
         )
         .then((tx) => tx.wait());
-    })
-  })
+      if (!result) {
+        expect.fail("Tx receipt not found");
+      }
+      const [depositEvent] = result.logs as EventLog[];
+      const { depositId } = depositEvent.args.toObject() as {
+        depositId: bigint;
+      };
+      const request = await claimRequest(
+        addr1,
+        ACCOUNT_TEST_PROFILE.alice.nostrPublicKey,
+        ACCOUNT_TEST_PROFILE.alice.nostrPrivateKey,
+        depositId,
+        gasAmount
+      );
+      await tipNostr
+        .connect(addr1)
+        .claim(request, gasAmount)
+        .then((tx) => tx.wait());
+      await expect(
+        tipNostr
+          .depositTo(
+            depositAmount,
+            await dualVMToken.getAddress(),
+            BigInt(`0x${ACCOUNT_TEST_PROFILE.alice.nostrPublicKey}`),
+            0n
+          )
+          .then((tx) => tx.wait())
+      )
+        .to.emit(tipNostr, "TransferEvent")
+        .withArgs(
+          owner.address,
+          BigInt(`0x${ACCOUNT_TEST_PROFILE.alice.nostrPublicKey}`),
+          addr1.address,
+          depositAmount,
+          await dualVMToken.getAddress()
+        );
+    });
+  });
+
+  describe("cancel", function () {
+    it("should cancel a deposit", async function () {
+      const depositAmount = 100n;
+      await dualVMToken
+        .starknetApprove(starknetDeposit.address, depositAmount)
+        .then((tx) => tx.wait());
+      const result = await tipNostr
+        .depositTo(
+          depositAmount,
+          await dualVMToken.getAddress(),
+          BigInt(`0x${ACCOUNT_TEST_PROFILE.bob.nostrPublicKey}`),
+          0n
+        )
+        .then((tx) => tx.wait());
+      if (!result) {
+        expect.fail("Tx receipt not found");
+      }
+      const [depositEvent] = result.logs as EventLog[];
+      const { depositId } = depositEvent.args.toObject() as {
+        depositId: bigint;
+      };
+      await expect(tipNostr.cancel(depositId).then((tx) => tx.wait()))
+        .to.emit(tipNostr, "CancelEvent")
+        .withArgs(
+          depositId,
+          owner.address,
+          BigInt(`0x${ACCOUNT_TEST_PROFILE.bob.nostrPublicKey}`),
+          depositAmount,
+          await dualVMToken.getAddress()
+        );
+      const { sender, amount, tokenAddress, nostrRecipient, ttl } =
+        await tipNostr.getDeposit(depositId);
+      expect({ sender, amount, tokenAddress, nostrRecipient, ttl }).to.include({
+        sender: ZeroAddress,
+        amount: 0n,
+        tokenAddress: ZeroAddress,
+        nostrRecipient: 0n,
+        ttl: 0n,
+      });
+    });
+  });
 
   describe("claim", function () {
-    it("Should deposit to a Nostr user", async function () {
-
+    it("should claim a deposit", async function () {
+      const depositAmount = 100n;
+      const gasAmount = 0n;
       await dualVMToken
-        .connect(addr1)
-        .approve(addr2.address, 100)
+        .starknetApprove(starknetDeposit.address, depositAmount)
         .then((tx) => tx.wait());
-      expect(
-        await dualVMToken.allowance(await addr1.address, addr2.address)
-      ).to.equal(100);
-
-
-      await tipNostr
-        .connect(addr1)
+      const senderBalanceBeforeDeposit = await dualVMToken.balanceOf(
+        owner.address
+      );
+      const result = await tipNostr
         .depositTo(
-          1n,
-          TOKEN_QUOTE_ADDRESS_KAKAROT,
-          // await dualVMToken.getAddress(),
-          alicePublicKeyUint256,
-          0
+          depositAmount,
+          await dualVMToken.getAddress(),
+          BigInt(`0x${ACCOUNT_TEST_PROFILE.bob.nostrPublicKey}`),
+          0n
         )
         .then((tx) => tx.wait());
-
-      // await tipNostr
-      //   .connect(addr1)
-      //   .depositTo(
-      //     1,
-      //     TOKEN_QUOTE_ADDRESS,
-      //     alicePublicKeyUint256,
-      //     0
-      //   )
-      //   .then((tx) => tx.wait());
-
-      // /** Start claim with Nostr event */
-
-      const content = `claim: ${cairo.felt(0)},${cairo.felt(
-        ownerStarknet!,
-      )},${cairo.felt(TOKEN_QUOTE_ADDRESS)},${BigInt(1).toString()}`;
-      const timestamp = new Date().getTime()
-      let privateKeyAlice = ACCOUNT_TEST_PROFILE?.alice?.nostrPrivateKey as any;
-      let privateKey = privateKeyAlice
-
-      // Sign Nostr event
-      const event = finalizeEvent(
-        {
-          kind: 1,
-          tags: [],
-          content: content,
-          created_at: timestamp,
-        },
-        privateKey
-      );
-
-      console.log(
-        "event",
-        event
-      );
-      const signature = event.sig;
-      const signatureR = "0x" + signature.slice(0, signature.length / 2);
-      const signatureS = "0x" + signature.slice(signature.length / 2);
-      console.log("signature", signature);
-      console.log("signatureR", signatureR);
-      console.log("signatureS", signatureS);
-      let public_key = BigInt("0x" + alicePublicKey)
-
-      /** @TODO fix conversion */
-      const claimParams = {
-        public_key: public_key,
-        created_at: new Date().getTime(),
-        kind: 1,
-        tags: ethers.toUtf8Bytes("[]"), // tags
-        content: {
-          deposit_id: ethers.toUtf8Bytes("0").slice(0, 31),
-          starknet_recipient: ownerStarknet,
-          gas_token_address: TOKEN_QUOTE_ADDRESS,
-          gas_amount: BigInt(0),
-        },
-        sig: {
-          r: signatureR,
-          s: signatureS
-        },
+      if (!result) {
+        expect.fail("Tx receipt not found");
+      }
+      const [depositEvent] = result.logs as EventLog[];
+      const { depositId } = depositEvent.args.toObject() as {
+        depositId: bigint;
       };
-
-      await tipNostr
-        .connect(addr1)
-        .claim(
-          claimParams,
-          // 1n,
-        )
-        .then((tx) => tx.wait());
-    })
-  })
-
-
+      const senderBalanceAfterDeposit = await dualVMToken.balanceOf(
+        owner.address
+      );
+      // const escrowBalanceBeforeClaim = await dualVMToken.starknetBalanceOf(
+      //   starknetDeposit.address
+      // );
+      const recipientBalanceBeforeClaim = await dualVMToken.balanceOf(
+        addr2.address
+      );
+      const request = await claimRequest(
+        addr2,
+        ACCOUNT_TEST_PROFILE.bob.nostrPublicKey,
+        ACCOUNT_TEST_PROFILE.bob.nostrPrivateKey,
+        depositId,
+        gasAmount
+      );
+      await expect(
+        tipNostr
+          .connect(addr2)
+          .claim(request, gasAmount)
+          .then((tx) => tx.wait())
+      )
+        .to.emit(tipNostr, "ClaimEvent")
+        .withArgs(
+          depositId,
+          addr2.address,
+          request.publicKey,
+          request.content.recipient,
+          depositAmount,
+          await dualVMToken.getAddress(),
+          request.content.gasTokenAddress,
+          request.content.gasAmount
+        );
+      // sender check
+      expect(senderBalanceBeforeDeposit - depositAmount).to.equal(
+        senderBalanceAfterDeposit,
+        "sender amount to deposit not send"
+      );
+      // recipient check
+      const recipientBalanceAfterClaim = await dualVMToken.balanceOf(
+        addr2.address
+      );
+      expect(recipientBalanceBeforeClaim).to.equal(
+        0n,
+        "recipient balance before claim != 0"
+      );
+      expect(recipientBalanceAfterClaim).to.equal(
+        depositAmount,
+        "recipient balance after claim != amount"
+      );
+      // escrow balance
+      // expect(escrowBalanceBeforeClaim).to.equal(
+      //   amount,
+      //   "escrow before claim != amount"
+      // );
+      // const escrowBalanceAfterClaim = await dualVMToken.starknetBalanceOf(
+      //   starknetDeposit.address
+      // );
+      // expect(escrowBalanceAfterClaim).to.equal(
+      //   0n,
+      //   "escrow balance after claim != 0"
+      // );
+    });
+  });
 });

--- a/onchain/tsconfig.json
+++ b/onchain/tsconfig.json
@@ -8,5 +8,10 @@
     "skipLibCheck": true,
     "resolveJsonModule": true
   },
-  "include": ["./tests", "./typechain-types", "scripts/config.ts"]
+  "include": [
+    "./tests",
+    "./hardhat.config.ts",
+    "./typechain-types",
+    "scripts/config.ts"
+  ]
 }


### PR DESCRIPTION
This PR implements the DepositEscrowNostr contract in Solidity as a proxy to the underlying DepositEscrow Cairo contract.
Tests have been written to ensure the underlying contract is correctly called and Solidity events are emitted accordingly.

TODO: I had to comment the Cairo events emissions because otherwise the Cairo calls from Solidity never return for some unknown reason.
Since we emit Solidity version of these contracts in the Solidity interface we still have something usable.

Closes #83 