### PR TITLE
improvement: precomputed hash of the bip340 tag

### DIFF
--- a/onchain/cairo/src/bip340.cairo
+++ b/onchain/cairo/src/bip340.cairo
@@ -41,7 +41,17 @@ const p: u256 = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC
 /// "BIP0340/challenge".
 fn hash_challenge(rx: u256, px: u256, m: ByteArray) -> u256 {
     // sha256(tag)
-    let [x0, x1, x2, x3, x4, x5, x6, x7] = compute_sha256_byte_array(@"BIP0340/challenge");
+    //Precomputed Values = compute_sha256_byte_array(@"BIP0340/challenge")
+    let (x0, x1, x2, x3, x4, x5, x6, x7) = (
+        2075471226,
+        2683263026,
+        1051836282,
+        1081979778,
+        3539202776,
+        464593487,
+        1241403791,
+        1833489276
+    );
 
     let mut ba = Default::default();
     // sha256(tag)


### PR DESCRIPTION
In BIP-340 file, the tag "BIP0340/challenge" is hashed with SHA256 every time the signature is being verified onchain. Writing the precomputed values of this hash would make the signature verification process more efficient.