### PR TITLE
feat: added hashtag and hashtag screen

### DIFF
--- a/apps/mobile/src/app/Router.tsx
+++ b/apps/mobile/src/app/Router.tsx
@@ -62,6 +62,7 @@ import {IconNames} from '../components/Icon';
 import {useAuth} from 'afk_nostr_sdk';
 import {Onboarding} from '../screens/Onboarding';
 import {initGoogleAnalytics, logPageView} from '../utils/analytics';
+import {TagsView} from '../screens/Tags';
 
 type TabBarIconProps = {
   focused: boolean;
@@ -286,6 +287,7 @@ const MainNavigator: React.FC = () => {
       <MainStack.Screen name="PostDetail" component={PostDetail} />
       <MainStack.Screen name="ChannelDetail" component={ChannelDetail} />
       <MainStack.Screen name="Search" component={Search} />
+      <MainStack.Screen name="Tags" component={TagsView} />
       <MainStack.Screen name="CreateChannel" component={CreateChannel} />
       <MainStack.Screen name="ChannelsFeed" component={ChannelsFeed} />
       <MainStack.Screen name="CreateForm" component={CreateForm} />
@@ -425,6 +427,7 @@ const linking = {
           ImportKeys: 'import-keys',
           Home: 'home',
           Feed: 'feed',
+          Tags: 'Tags',
           Profile: {
             path: 'profile/:publicKey',
             parse: {

--- a/apps/mobile/src/components/Badge/index.tsx
+++ b/apps/mobile/src/components/Badge/index.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import {Text, View, ViewStyle} from 'react-native';
+
+import {useStyles} from '../../hooks';
+import styleSheet from './styles';
+
+type BadgeProps = {
+  value: string;
+  status?: 'default';
+  style?: ViewStyle;
+};
+
+const Badge: React.FC<BadgeProps> = ({value, status = 'default', style}) => {
+  const styles = useStyles(styleSheet);
+  return (
+    <View style={[styles.badge, styles[status], style]}>
+      <Text style={styles.badgeText}>{value}</Text>
+    </View>
+  );
+};
+
+export default Badge;

--- a/apps/mobile/src/components/Badge/styles.ts
+++ b/apps/mobile/src/components/Badge/styles.ts
@@ -1,0 +1,20 @@
+import {ThemedStyleSheet} from '../../styles';
+
+export default ThemedStyleSheet((theme) => ({
+  badge: {
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 7,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: theme.colors.badgeBorder,
+  },
+  badgeText: {
+    fontSize: 12,
+    color: theme.colors.badgeText,
+  },
+  default: {
+    backgroundColor: theme.colors.badge,
+  },
+}));

--- a/apps/mobile/src/modules/Post/styles.ts
+++ b/apps/mobile/src/modules/Post/styles.ts
@@ -68,6 +68,7 @@ export default ThemedStyleSheet((theme) => ({
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
+    overflowX: 'scroll',
   },
   footerComments: {
     flexDirection: 'row',

--- a/apps/mobile/src/modules/PostCard/index.tsx
+++ b/apps/mobile/src/modules/PostCard/index.tsx
@@ -1,7 +1,9 @@
 import {NDKEvent, NDKKind} from '@nostr-dev-kit/ndk';
 import {useState} from 'react';
-import {View} from 'react-native';
+import React from 'react';
+import {Pressable, View} from 'react-native';
 
+import {Text} from '../../components';
 import {useStyles} from '../../hooks';
 import {Post} from '../Post';
 import stylesheet from './styles';
@@ -11,13 +13,14 @@ export type PostCardProps = {
   isRepostProps?: boolean;
   isBookmarked?: boolean;
 };
+const hashtags = /\B#\w*[a-zA-Z]+\w*/g;
 
 export const PostCard: React.FC<PostCardProps> = ({event, isRepostProps, isBookmarked}) => {
   const styles = useStyles(stylesheet);
 
   let repostedEvent = undefined;
   const [isRepost, setIsRepost] = useState(
-    isRepostProps ?? event?.kind == NDKKind.Repost ? true : false,
+    (isRepostProps ?? event?.kind == NDKKind.Repost) ? true : false,
   );
 
   if (event?.kind == NDKKind.Repost) {
@@ -33,5 +36,34 @@ export const PostCard: React.FC<PostCardProps> = ({event, isRepostProps, isBookm
         isBookmarked={isBookmarked}
       />
     </View>
+  );
+};
+
+const ClickableHashtag = ({hashtag, onPress}: any) => {
+  const styles = useStyles(stylesheet);
+  return (
+    <Pressable>
+      <Text style={styles.hashtagColor} onPress={() => onPress(hashtag)}>
+        {hashtag}
+      </Text>
+    </Pressable>
+  );
+};
+
+export const ContentWithClickableHashtags = ({content, onHashtagPress}: any) => {
+  const parts = content.split(hashtags);
+  const matches = content.match(hashtags);
+
+  return (
+    <Text color="textStrong" fontSize={13} lineHeight={20}>
+      {parts.map((part: string, index: number) => (
+        <React.Fragment key={index}>
+          {part}
+          {matches && index < parts.length - 1 && (
+            <ClickableHashtag hashtag={matches[index]} onPress={onHashtagPress} />
+          )}
+        </React.Fragment>
+      ))}
+    </Text>
   );
 };

--- a/apps/mobile/src/modules/PostCard/styles.ts
+++ b/apps/mobile/src/modules/PostCard/styles.ts
@@ -8,4 +8,8 @@ export default ThemedStyleSheet((theme) => ({
     marginBottom: Spacing.large,
     borderRadius: 16,
   },
+  hashtagColor: {
+    color: theme.colors.primary,
+    textDecorationLine: 'underline',
+  },
 }));

--- a/apps/mobile/src/modules/Swap/index.tsx
+++ b/apps/mobile/src/modules/Swap/index.tsx
@@ -268,7 +268,9 @@ export default function TokenSwapView({showHeader = false}: {showHeader?: boolea
           </View>
           <View style={styles.balanceEstimate}>
             <Text style={styles.estimate}>≈ {estUsdValue}</Text>
-            <Text style={styles.balance}>{fromBalance ? `$${fromBalance?.formatted}` : ''}</Text>
+            <Text style={styles.balance}>
+              {fromBalance ? parseFloat(fromBalance?.formatted).toFixed(5) : ''}
+            </Text>
           </View>
         </View>
 
@@ -313,7 +315,9 @@ export default function TokenSwapView({showHeader = false}: {showHeader?: boolea
           </View>
           <View style={styles.balanceEstimate}>
             <Text style={styles.estimate}>≈ {estUsdValue}</Text>
-            <Text style={styles.balance}>{toBalance ? `$${toBalance?.formatted}` : ''}</Text>
+            <Text style={styles.balance}>
+              {toBalance ? parseFloat(toBalance?.formatted).toFixed(5) : ''}
+            </Text>
           </View>
         </View>
 

--- a/apps/mobile/src/screens/Tags/index.tsx
+++ b/apps/mobile/src/screens/Tags/index.tsx
@@ -1,0 +1,101 @@
+import {NDKKind} from '@nostr-dev-kit/ndk';
+import {useAllProfiles, useSearch} from 'afk_nostr_sdk';
+import {useEffect, useMemo, useState} from 'react';
+import {FlatList, Image, Pressable, RefreshControl, Text, View} from 'react-native';
+
+import {AddPostIcon} from '../../assets/icons';
+import {BubbleUser} from '../../components/BubbleUser';
+import {useStyles, useTheme} from '../../hooks';
+import {ChannelComponent} from '../../modules/ChannelCard';
+import {PostCard} from '../../modules/PostCard';
+import {TagsScreenProps} from '../../types';
+import stylesheet from './styles';
+
+export const TagsView: React.FC<TagsScreenProps> = ({navigation, route}) => {
+  const {theme} = useTheme();
+  const styles = useStyles(stylesheet);
+  const profiles = useAllProfiles({limit: 10});
+  const [feedData, setFeedData] = useState(null);
+  const [kinds] = useState<NDKKind[]>([
+    NDKKind.Text,
+    NDKKind.ChannelCreation,
+    NDKKind.GroupChat,
+    NDKKind.ChannelMessage,
+    NDKKind.Metadata,
+  ]);
+
+  const notes = useSearch({
+    kinds,
+    limit: 10,
+  });
+
+  // Filter notes based on the hashtag present in the URL query
+  const filteredNotes = useMemo(() => {
+    const urlQuery = route?.params.tagName;
+    if (!notes.data?.pages || !urlQuery) return [];
+
+    const flattenedPages = notes.data.pages.flat();
+    return flattenedPages.filter((item) =>
+      item?.tags?.some((tag: any) => tag[0] === 't' && tag[1] === urlQuery),
+    );
+  }, [notes.data?.pages, route?.params.tagName]);
+
+  // Update the feedData when filtered notes change
+  useEffect(() => {
+    setFeedData(filteredNotes as any);
+  }, [filteredNotes]);
+
+  const renderHeader = () => (
+    <View style={styles.headerContainer}>
+      <Text style={styles.hashtagText}>#{route?.params.tagName}</Text>
+      <Text style={styles.noteCount}>{filteredNotes.length} notes</Text>
+      <FlatList
+        contentContainerStyle={styles.stories}
+        horizontal
+        data={profiles?.data?.pages?.flat()}
+        showsHorizontalScrollIndicator={false}
+        onEndReached={() => profiles.fetchNextPage()}
+        refreshControl={
+          <RefreshControl refreshing={profiles.isFetching} onRefresh={() => profiles.refetch()} />
+        }
+        ItemSeparatorComponent={() => <View style={styles.storySeparator} />}
+        renderItem={({item}) => <BubbleUser event={item} />}
+      />
+    </View>
+  );
+
+  return (
+    <View style={styles.container}>
+      <Image
+        style={styles.backgroundImage}
+        source={require('../../assets/feed-background-afk.png')}
+        resizeMode="cover"
+      />
+      <FlatList
+        ListHeaderComponent={renderHeader}
+        contentContainerStyle={styles.flatListContent}
+        data={feedData}
+        keyExtractor={(item) => item?.id}
+        renderItem={({item}) => {
+          if (item.kind === NDKKind.ChannelCreation || item.kind === NDKKind.ChannelMetadata) {
+            return <ChannelComponent event={item} />;
+          } else if (item.kind === NDKKind.ChannelMessage || item.kind === NDKKind.Text) {
+            return <PostCard event={item} />;
+          }
+          return null;
+        }}
+        refreshControl={
+          <RefreshControl refreshing={notes.isFetching} onRefresh={() => notes.refetch()} />
+        }
+        onEndReached={() => notes.fetchNextPage()}
+      />
+
+      <Pressable
+        style={styles.createPostButton}
+        onPress={() => navigation.navigate('MainStack', {screen: 'CreateForm'})}
+      >
+        <AddPostIcon width={72} height={72} color={theme.colors.primary} />
+      </Pressable>
+    </View>
+  );
+};

--- a/apps/mobile/src/screens/Tags/styles.ts
+++ b/apps/mobile/src/screens/Tags/styles.ts
@@ -1,0 +1,56 @@
+import {Spacing, ThemedStyleSheet} from '../../styles';
+
+export default ThemedStyleSheet((theme) => ({
+  backgroundImage: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+  },
+
+  createPostButton: {
+    position: 'absolute',
+    bottom: Spacing.large,
+    right: Spacing.pagePadding,
+    color: theme.colors.primary,
+  },
+
+  container: {
+    flex: 1,
+    backgroundColor: theme.colors.background,
+  },
+
+  flatListContent: {
+    marginTop: 20,
+    paddingBottom: 80,
+  },
+  stories: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+  },
+  storySeparator: {
+    width: 8,
+  },
+
+  headerContainer: {
+    marginBottom: 20,
+    padding: 10,
+    paddingVertical: 5,
+    paddingHorizontal: 18,
+    borderBottomWidth: 1,
+    borderBottomColor: theme.colors.divider,
+  },
+  hashtagText: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: theme.colors.text,
+    marginBottom: 4,
+  },
+  noteCount: {
+    fontSize: 16,
+    color: theme.colors.textSecondary,
+    marginBottom: 8,
+    marginLeft: 14,
+  },
+}));

--- a/apps/mobile/src/styles/Colors.tsx
+++ b/apps/mobile/src/styles/Colors.tsx
@@ -18,6 +18,10 @@ export const LightTheme = {
     ...CommonColors,
     red: '#EC796B',
 
+    badge: '#F2F2F2',
+    badgeText: '#333333',
+    badgeBorder: '#CCCCCC',
+
     messageCard: '#FFFFFF',
     messageCardText: '#14142C',
 
@@ -94,6 +98,10 @@ export const DarkTheme = {
   colors: {
     ...CommonColors,
     red: '#EC796B',
+
+    badge: '#2C2C2C',
+    badgeText: '#B3B3B3',
+    badgeBorder: '#444444',
 
     messageCard: '#2C2C2C',
     messageCardText: '#FFFFFF',

--- a/apps/mobile/src/types/routes.ts
+++ b/apps/mobile/src/types/routes.ts
@@ -38,6 +38,7 @@ export type MainStackParams = {
     post?: NDKEvent;
     groupAccess: string;
   };
+  Tags: {tagName: string; post?: NDKEvent};
   EditProfile: undefined;
   Search: undefined;
   CreateChannel: undefined;
@@ -190,6 +191,11 @@ export type CreatePostScreenProps = CompositeScreenProps<
 
 export type ProfileScreenProps = CompositeScreenProps<
   NativeStackScreenProps<MainStackParams, 'Profile'>,
+  NativeStackScreenProps<RootStackParams>
+>;
+
+export type TagsScreenProps = CompositeScreenProps<
+  NativeStackScreenProps<MainStackParams, 'Tags'>,
   NativeStackScreenProps<RootStackParams>
 >;
 

--- a/apps/mobile/src/utils/helpers.ts
+++ b/apps/mobile/src/utils/helpers.ts
@@ -61,3 +61,7 @@ export const dataURLToBlob = (dataURL: string) => {
 export const getImageRatio = (width: number, height: number, minRatio = 0.75, maxRatio = 1.5) => {
   return Math.max(minRatio, Math.min(maxRatio, width / height));
 };
+
+export function removeHashFn(str: string) {
+  return str.replace(/#/g, '');
+}


### PR DESCRIPTION
As part of this [issue ](https://github.com/AFK-AlignedFamKernel/afk_monorepo/issues/184)

1. Implemented automatic hashtag detection in note creation. When users type # followed by text, the system automatically detects it as a hashtag.
2. Enhanced the  notes Card UI to display detected hashtags as clickable badges within notes.
3. Added a feature to allow users to click a hashtag badge, which redirects them to a dedicated page showing all notes associated with that tag.
4. Removed $ dollar sign from token balance in Swap.

<img width="1175" alt="Screenshot 2024-10-16 at 16 29 15" src="https://github.com/user-attachments/assets/e5bc40f7-3275-4958-89e2-40a3a9e1d72f">
<img width="880" alt="Screenshot 2024-10-16 at 18 15 31" src="https://github.com/user-attachments/assets/2a2166a0-6aa4-4d5b-9227-c9d71dd121e0">
<img width="824" alt="Screenshot 2024-10-16 at 18 20 31" src="https://github.com/user-attachments/assets/4bf53fc5-29be-4eaf-ab2a-d0e7679eba7e">
