### PR TITLE
fix: use account hook from store and set account state on reconnect

### DIFF
--- a/packages/pixel_ui/src/App.tsx
+++ b/packages/pixel_ui/src/App.tsx
@@ -71,13 +71,15 @@ function App({ contractAddress, usernameAddress, nftCanvasAddress }: IApp) {
   const { 
     connectWallet, 
     startSession,
-    account, address,
+    account,
+    address,
     queryAddress,
     setConnected,
     isSessionable,
     disconnectWallet,
     usingSessionKeys 
   } = useWalletStore()
+
 
   //Connect
   useQueryAddressEffect()

--- a/packages/pixel_ui/src/footer/PixelSelector.js
+++ b/packages/pixel_ui/src/footer/PixelSelector.js
@@ -1,9 +1,10 @@
 import './PixelSelector.css';
 import '../utils/Styles.css';
+import {  useWalletStore } from '../hooks/useWalletStore';
 
 import React, {useEffect, useState} from 'react';
 import {
-  useAccount,
+  // useAccount,
   // useContract,
   // useNetwork,
   // useConnect
@@ -12,13 +13,19 @@ import {
 import EraserIcon from '../resources/icons/Eraser.png';
 
 const PixelSelector = (props) => {
+
+  //Use account hooks from store.
+  const { 
+    account,
+  } = useWalletStore()
+
   // Track when a placement is available
 
-  const {account} = useAccount()
 
   const [placementTimer, setPlacementTimer] = useState('XX:XX');
   const [placementMode, setPlacementMode] = useState(false);
   const [ended, setEnded] = useState(false);
+
   useEffect(() => {
     if (props.queryAddress === '0' || !account?.address) {
       setPlacementTimer('Login to Play');

--- a/packages/pixel_ui/src/hooks/useWalletStore.ts
+++ b/packages/pixel_ui/src/hooks/useWalletStore.ts
@@ -110,6 +110,10 @@ const canSession = (wallet) => {
         if (wallet && connectorData && connector) {
 
           const new_account = await connector.account(provider);
+
+          console.log(new_account, "sjsjsj")
+
+  
           set({
             wallet,
             connectorData:{account:connectorData?.account,chainId: connectorData.chainId ? BigInt(connectorData.chainId).toString(): undefined},
@@ -231,6 +235,7 @@ const canSession = (wallet) => {
 
   export const useAutoConnect = () => {
     const {setWallet, setConnector, setConnectorData,connectorData, setIsSessionable,
+      setAccount,
       } = useWalletStore()
   
     useEffect(() => {
@@ -246,7 +251,8 @@ const canSession = (wallet) => {
               icons: []
             }
           });
-  
+          const new_account = await connector.account(provider);
+          setAccount(new_account)
           setConnector(connector);
           setWallet(connectedWallet)
           setIsSessionable(canSession(connectedWallet))
@@ -266,7 +272,7 @@ const canSession = (wallet) => {
       if (!connectorData) {
         autoConnect();
       }
-    }, [setConnector, setConnectorData, connectorData, setIsSessionable, setWallet]);
+    }, [setConnector, setConnectorData, connectorData, setIsSessionable, setWallet, setAccount]);
 
     useEffect(() => {
         if (typeof window !== "undefined") {


### PR DESCRIPTION
Use `account` state from `useWalletStore` hook instead of from startnet `useAccount` hook directly as that will be undefined.
