### PR TITLE
Fix: Launchpad render only Tokens launched [STAGE1]

### DIFF
--- a/apps/mobile/src/hooks/api/indexer/useMyTokensCreated.ts
+++ b/apps/mobile/src/hooks/api/indexer/useMyTokensCreated.ts
@@ -1,11 +1,12 @@
 import {useQuery} from '@tanstack/react-query';
+
 import {ApiIndexerInstance} from '../../../services/api';
 
-export const useMyTokensCreated = (userAddress: string) => {
+export const useMyTokensCreated = (userAddress?: string) => {
   return useQuery({
     queryKey: userAddress ? ['token', userAddress] : ['deploy_token_by_user'],
     queryFn: async () => {
-      const endpoint = `/deploy/by/${userAddress}`
+      const endpoint = `/deploy/by/${userAddress}`;
       const res = await ApiIndexerInstance.get(endpoint);
       if (res.status !== 200) {
         throw new Error('Failed to fetch token launch');

--- a/apps/mobile/src/hooks/useCombinedTokens.ts
+++ b/apps/mobile/src/hooks/useCombinedTokens.ts
@@ -1,4 +1,4 @@
-import {useEffect, useMemo, useState} from 'react';
+import {useEffect, useState} from 'react';
 
 import {LaunchDataMerged} from '../types/keys';
 import {useGetDeployToken} from './api/indexer/useDeployToken';
@@ -21,28 +21,25 @@ export const useCombinedTokenData = (token?: string, launch?: string) => {
   const [tokens, setTokens] = useState<LaunchDataMerged[]>([]);
   const [launches, setLaunches] = useState<LaunchDataMerged[]>([]);
 
-  const combinedData = useMemo(() => {
-    return [
-      ...(deployData?.data || []),
-      //  ...(launchData?.data || [])
-    ];
-  }, [deployData, launchData]);
-
-  const launchDataCombined = useMemo(() => {
-    return [
-      ...(launchData?.data || []),
-      //  ...(launchData?.data || [])
-    ];
-  }, [deployData, launchData]);
-
   useEffect(() => {
-    setTokens(combinedData);
-    setLaunches(launchDataCombined);
-  }, [combinedData]);
+    setTokens(deployData.data || []);
+
+    if (launchData.data) {
+      setLaunches(
+        launchData.data.map((launchToken: any) => ({
+          ...(deployData.data.find(
+            (deployedToken: LaunchDataMerged) =>
+              deployedToken.token_address === launchToken.token_address,
+          ) || {}),
+          ...launchToken,
+        })),
+      );
+    }
+  }, [deployData, launchData]);
 
   return {
     tokens,
-    launches: launchDataCombined,
+    launches,
     isLoading: isLoadingDeploy || isLoadingLaunch,
     isError: isErrorDeploy || isErrorLaunch,
     isFetching: launchIsFetching || tokenIsFetching,

--- a/apps/mobile/src/screens/Launchpad/LaunchpadComponent.tsx
+++ b/apps/mobile/src/screens/Launchpad/LaunchpadComponent.tsx
@@ -45,12 +45,12 @@ export const LaunchpadComponent: React.FC<AllKeysComponentInterface> = ({
   useEffect(() => {
     if (tokens?.length != tokensStore?.length) {
       setTokens(tokens);
-      setLaunches(tokens);
+      setLaunches(launchesData);
     }
 
     console.log('tokens', tokens);
     console.log('tokensStore', tokensStore);
-  }, [tokens, tokensStore]);
+  }, [tokens, launchesData, tokensStore]);
   return (
     <View style={styles.container}>
       {isLoading && <ActivityIndicator></ActivityIndicator>}


### PR DESCRIPTION
- [x] Do the change in the useCombinedData hooks [STAGE1]
- [ ] After we need to create an optimized endpoint for it in apps/data-backend [STAGE2]

## Stage 1 
rewrite useCombinedData() hook to correctly enrich launch_token with deploy_token data