### PR TITLE
Fixes type errors in bip 340 

### DIFF
--- a/onchain/cairo/afk/src/bip340.cairo
+++ b/onchain/cairo/afk/src/bip340.cairo
@@ -573,7 +573,7 @@ mod tests {
         let message: ByteArray = "I love Cairo";
 
         // Sign message
-        let signature = sign(private_key, message);
+        let signature = sign(private_key, message.clone());
 
         // Verify signature
         let is_valid = verify_sig(public_key, message, signature);
@@ -589,7 +589,7 @@ mod tests {
         let message: ByteArray = "I love Cairo";
 
         // Sign message
-        let signature = sign(private_key, message);
+        let signature = sign(private_key, message.clone()); 
 
         // Verify signature
         let is_valid = verify_sig(public_key, message, signature);

--- a/onchain/cairo/afk/src/social/namespace.cairo
+++ b/onchain/cairo/afk/src/social/namespace.cairo
@@ -2,6 +2,7 @@ use core::fmt::Display;
 use core::to_byte_array::FormatAsByteArray;
 use starknet::{get_caller_address, get_contract_address, get_tx_info, ContractAddress};
 use super::request::{SocialRequest, SocialRequestImpl, SocialRequestTrait, Encode, Signature};
+use super::request::ConvertToBytes;
 
 // Add this ROLE on a constants file
 pub const OPERATOR_ROLE: felt252 = selector!("OPERATOR_ROLE");
@@ -34,7 +35,14 @@ impl LinkedStarknetAddressEncodeImpl of Encode<LinkedStarknetAddress> {
         @format!("link to {:?}", recipient_address_user_felt)
     }
 }
-
+impl LinkedStarknetAddressImpl of ConvertToBytes<LinkedStarknetAddress> {
+    fn convert_to_bytes(self: @LinkedStarknetAddress) -> ByteArray {
+        let mut ba: ByteArray = "";
+        let starknet_address_felt: felt252 = (*self.starknet_address).into();
+        ba.append_word(starknet_address_felt, 1_u32);
+        ba
+    }
+}
 #[derive(Copy, Debug, Drop, Serde)]
 pub enum LinkedResult {
     Transfer: ContractAddress,

--- a/onchain/cairo/afk/src/social/request.cairo
+++ b/onchain/cairo/afk/src/social/request.cairo
@@ -27,7 +27,9 @@ pub struct SocialRequest<C> {
 pub trait Encode<T> {
     fn encode(self: @T) -> @ByteArray;
 }
-
+pub trait ConvertToBytes<T> {
+    fn convert_to_bytes(self: @T) -> ByteArray;
+}
 #[generate_trait]
 pub impl SocialRequestImpl<C, +Encode<C>> of SocialRequestTrait<C> {
     fn verify(self: @SocialRequest<C>) -> Option<u256> {

--- a/onchain/cairo/afk/src/tests/nameservice_tests.cairo
+++ b/onchain/cairo/afk/src/tests/nameservice_tests.cairo
@@ -234,9 +234,7 @@ mod nameservice_tests {
         stop_cheat_caller_address(nameservice_dispatcher.contract_address);
 
         let admin_balance = payment_token_dispatcher.balance_of(ADMIN());
-        assert(
-            admin_balance == 60_u256, 'Admin did not receive fees'
-        ); // 50 initial + 10 withdrawn
+        assert(admin_balance == 60_u256, 'Admin did not receive fees'); // 50 initial + 10 withdrawn
 
         let contract_balance = payment_token_dispatcher
             .balance_of(nameservice_dispatcher.contract_address);

--- a/onchain/cairo/afk/src/types/keys_types.cairo
+++ b/onchain/cairo/afk/src/types/keys_types.cairo
@@ -118,7 +118,7 @@ pub fn get_current_price(key: @Keys, supply: u256, amount_to_buy: u256) -> u256 
 
 
 pub fn get_linear_price( // key: @Keys, 
-    key: Keys, supply: u256, //  amount_to_buy: u256
+key: Keys, supply: u256, //  amount_to_buy: u256
 ) -> u256 {
     let step_increase_linear = key.token_quote.step_increase_linear.clone();
     let initial_key_price = key.token_quote.initial_key_price.clone();


### PR DESCRIPTION
I need some help in converting `content` field of 
```
#[derive(Debug, Drop, Serde)]
pub struct SocialRequest<C> {
    pub public_key: u256,
    pub created_at: u64,
    pub kind: u16,
    pub tags: ByteArray, // we don't need to look inside the tags(at least for now)
    pub content: C,
    pub sig: Signature
}
```