### PR TITLE
Allow to start data-backend into local env

### DIFF
--- a/apps/data-backend/src/config/index.ts
+++ b/apps/data-backend/src/config/index.ts
@@ -38,8 +38,15 @@ const rawConfig = {
   },
 } as const;
 
-// Parse and validate the configuration
-export const config = ConfigSchema.parse(rawConfig);
+// Parse and validate the configurations
+export const configRes = ConfigSchema.safeParse(rawConfig);
+
+if (!configRes.success) {
+  console.error('Environment variables are missing or not valid:', configRes.error.issues);
+  process.exit(1);
+}
+
+export const config = configRes.data;
 
 // Type inference
 export type Config = z.infer<typeof ConfigSchema>;

--- a/apps/data-backend/src/config/index.ts
+++ b/apps/data-backend/src/config/index.ts
@@ -7,39 +7,65 @@ import dotenv from 'dotenv';
 dotenv.config();
 
 // Create the config object
-const rawConfig = {
-  jwt: {
-    secret: process.env.JWT_SECRET || 'your-secret-key',
-    accessTokenExpiry: '30m',
-    refreshTokenExpiry: '7d',
-  },
-  server: {
-    port: parseInt(process.env.PORT || '5050', 10),
-    host: process.env.HOST || '0.0.0.0',
-  },
-  cloudinary: {
-    cloud_name: process.env.CLOUDINARY_CLOUD_NAME || '',
-    api_key: process.env.CLOUDINARY_API_KEY || '',
-    api_secret: process.env.CLOUDINARY_API_SECRET || '',
-  },
-  rpc: {
-    starknetRpcUrl: process.env.STARKNET_RPC_PROVIDER_URL || '',
-    starknetNetwork: process.env.STARKNET_RPC_NETWORK || '',
-    api_key: process.env.RPC_NODE_API_KEY || '',
-    network: process.env.SN_NETWORK || '',
-  },
-  cloudfare: {
-    accountId: process.env.CLOUDFARE_ACCOUNT_ID || '',
-    token: process.env.CLOUDFARE_AUTH_TOKEN || '',
-    r2BucketName: process.env.CLOUDFARE_R2_BUCKET || '',
-    r2Access: process.env.CLOUDFARE_R2_ACCESS || '',
-    r2Secret: process.env.CLOUDFARE_R2_SECRET || '',
-    r2Domain: process.env.CLOUDFARE_R2_DOMAIN || '',
-  },
-} as const;
+function getConfig() {
+  const rawConfig = {
+    jwt: {
+      secret: process.env.JWT_SECRET || '',
+      accessTokenExpiry: '30m',
+      refreshTokenExpiry: '7d',
+    },
+    server: {
+      port: parseInt(process.env.PORT || '5050', 10),
+      host: process.env.HOST || '0.0.0.0',
+    },
+    cloudinary: {
+      cloud_name: process.env.CLOUDINARY_CLOUD_NAME || '',
+      api_key: process.env.CLOUDINARY_API_KEY || '',
+      api_secret: process.env.CLOUDINARY_API_SECRET || '',
+    },
+    rpc: {
+      starknetRpcUrl: process.env.STARKNET_RPC_PROVIDER_URL || '',
+      starknetNetwork: process.env.STARKNET_RPC_NETWORK || '',
+      api_key: process.env.RPC_NODE_API_KEY || '',
+      network: process.env.SN_NETWORK || '',
+    },
+    cloudfare: {
+      accountId: process.env.CLOUDFARE_ACCOUNT_ID || '',
+      token: process.env.CLOUDFARE_AUTH_TOKEN || '',
+      r2BucketName: process.env.CLOUDFARE_R2_BUCKET || '',
+      r2Access: process.env.CLOUDFARE_R2_ACCESS || '',
+      r2Secret: process.env.CLOUDFARE_R2_SECRET || '',
+      r2Domain: process.env.CLOUDFARE_R2_DOMAIN || '',
+    },
+  } as const;
+
+  if (process.env.NODE_ENV === 'development') {
+    return {
+      ...rawConfig,
+      jwt: {
+        ...rawConfig.jwt,
+        secret: rawConfig.jwt.secret || 'a secret with minimum length of 32 characters',
+      },
+      cloudinary: {
+        cloud_name: rawConfig.cloudinary.cloud_name || 'default_name',
+        api_key: rawConfig.cloudinary.api_key || 'KEY_xxxxxx',
+        api_secret: rawConfig.cloudinary.api_secret || 'SECRET_xxxxxx',
+      },
+      cloudfare: {
+        accountId: rawConfig.cloudfare.accountId || 'ID_xxxxxx',
+        token: rawConfig.cloudfare.token || 'TOKEN_xxxxxx',
+        r2BucketName: rawConfig.cloudfare.r2BucketName || 'default_name',
+        r2Access: rawConfig.cloudfare.r2Access || 'ACCESS_xxxxxx',
+        r2Secret: rawConfig.cloudfare.r2Secret || 'SECRET_xxxxxx',
+        r2Domain: rawConfig.cloudfare.r2Domain || 'DOMAIN_xxxxxx',
+      },
+    };
+  }
+  return rawConfig;
+}
 
 // Parse and validate the configurations
-export const configRes = ConfigSchema.safeParse(rawConfig);
+export const configRes = ConfigSchema.safeParse(getConfig());
 
 if (!configRes.success) {
   console.error('Environment variables are missing or not valid:', configRes.error.issues);

--- a/apps/data-backend/src/index.ts
+++ b/apps/data-backend/src/index.ts
@@ -1,17 +1,13 @@
 import Fastify from 'fastify';
-import fs from 'fs';
 import fastifyCors from '@fastify/cors';
 import fastifyIO from 'fastify-socket.io';
 import { Server as SocketIOServer } from 'socket.io';
 import path from 'path';
 import { config } from './config';
 import { setupWebSocket } from './services/livestream/socket';
-import { authRoutes } from './routes/auth';
-import { indexerRoutes } from './routes/indexer/index';
 import authPlugin from './plugins/auth';
 import jwt from 'jsonwebtoken';
 import prismaPlugin from './plugins/prisma';
-import twitterPlugin from './plugins/twitter-oauth';
 import { launchBot } from './services/telegram-app';
 import declareRoutes from './router';
 import fastifySession from '@fastify/session';
@@ -84,7 +80,7 @@ async function buildServer() {
   });
 
   fastify.register(fastifySession, {
-    secret: JWT_SECRET ?? 'your-secret-key',
+    secret: JWT_SECRET,
     cookie: { secure: process.env.NODE_ENV == 'production' ? true : false }, // Set to true in production
   });
 


### PR DESCRIPTION
## Description

This PR allows starting the data-backend service in a local dev environment without setting up all optional services.  
The idea is to minimize the effort required for developers to set up a simple local environment.

:warning: This modification only takes effect if `NODE_ENV` is set to `"development"`. I have ensured that it does not affect the production runtime.

- [x] Log a warning message instead of crashing the process if `TELEGRAM_WEB_APP` is not correctly defined (only in the dev environment).  
- [x] Define dummy environment values for all third-party services (only in the dev environment).  
- [x] Improve startup error messages (for both dev and prod).  

## PLEASE REVIEW WITH ATTENTION  

I did my best to avoid impacting the production runtime, but I am not very familiar with the production deployment process and environment context.  
So please be extra careful during the review!

## Possible improvements  

This PR is a first step toward enabling the startup of `data-backend` for routes that only use the database.  
Here is a list of possible future improvements:

- [ ] Refactor and centralize all remaining `process.env` configurations (RPC, Stripe, ...).  
- [ ] Improve Telegram app validation by removing the dummy `TELEGRAM_BOT_TOKEN` value from `.env.example`.  
- [ ] Extract the Telegram app into a dedicated process ??  
