### PR TITLE
fix docker deploy on railway 

### DIFF
--- a/railway.data-backend.Dockerfile
+++ b/railway.data-backend.Dockerfile
@@ -152,6 +152,7 @@ COPY --from=base /app/node_modules ./node_modules
 COPY --from=base /app/packages/common ./node_modules/common
 COPY --from=base /app/packages/prisma-db ./node_modules/prisma-db
 COPY --from=base /app/packages/indexer-prisma ./node_modules/indexer-prisma
+COPY --from=base /app/apps/data-backend/node_modules ./apps/data-backend/node_modules
 COPY --from=base /app/apps/data-backend/dist ./apps/data-backend/dist
 
 # Copy only necessary files for the application to run

--- a/railway.indexer.Dockerfile
+++ b/railway.indexer.Dockerfile
@@ -61,8 +61,9 @@ WORKDIR /app
 
 # Copy the node_modules and built files from the base stage
 COPY --from=base /app/node_modules ./node_modules
-COPY --from=base /app/packages/common ../node_modules/common
-COPY --from=base /app/packages/indexer-prisma ././node_modules/indexer-prisma
+COPY --from=base /app/packages/common ./node_modules/common
+COPY --from=base /app/packages/indexer-prisma ./node_modules/indexer-prisma
+COPY --from=base /app/apps/nestjs-indexer/node_modules ./apps/nestjs-indexer/node_modules
 COPY --from=base /app/apps/nestjs-indexer/dist ./apps/nestjs-indexer/dist
 
 # Copy only necessary files for the application to run


### PR DESCRIPTION
In Dockerfile files we do not copy the contents of local node_modules, which leads to versioning problems in dependencies

That's now fixed
