### PR TITLE
Audit: DDOS Distribute creator fee when change the variable

### DIFF
--- a/onchain/cairo/launchpad/src/launchpad/launchpad.cairo
+++ b/onchain/cairo/launchpad/src/launchpad/launchpad.cairo
@@ -1121,7 +1121,8 @@ pub mod LaunchpadMarketplace {
                 .is_creator_fee_sent_before_graduated
                 .read();
 
-
+            assert(launch.is_liquidity_launch == true, errors::NOT_LAUNCHED_YET);
+            // Check if creator fees are accumulated to be be distributed at the launch
             assert(launch.creator_amount_to_distribute > 0_u256, errors::NO_FEE_RECEIVED);
             let quote_token = IERC20Dispatcher {
                 contract_address: launch.token_quote.token_address
@@ -1131,13 +1132,11 @@ pub mod LaunchpadMarketplace {
             let creator_fee_distributed = launch.creator_amount_distributed;
             let creator_fee_to_distribute = launch.creator_amount_to_distribute;
 
-            if !is_creator_fee_sent_before_graduated && launch.is_liquidity_launch == true {
-                quote_token.transfer(launch.creator_fee_destination, creator_fee_to_distribute);
-                launch.creator_amount_received = 0_u256;
-                launch.creator_amount_distributed += creator_fee_to_distribute;
-                launch.creator_amount_to_distribute = 0_u256;
-                self.launched_coins.entry(coin_address).write(launch);
-            }
+            launch.creator_amount_received = 0_u256;
+            launch.creator_amount_distributed += creator_fee_to_distribute;
+            launch.creator_amount_to_distribute = 0_u256;
+            quote_token.transfer(launch.creator_fee_destination, creator_fee_to_distribute);
+            self.launched_coins.entry(coin_address).write(launch);
 
             self
                 .emit(


### PR DESCRIPTION
distribute_creator_fee

- [ ] assertion to be only callable when you the pool is launched and you have fee to be distributed
- [ ] fix check change variable DDOS + function only when you pool liq launched and fees are accumulated to be distributed later
